### PR TITLE
adding localisation logic

### DIFF
--- a/crate/multiworld/src/config.rs
+++ b/crate/multiworld/src/config.rs
@@ -10,7 +10,10 @@ use {
         Serialize,
     },
     url::Url,
-    crate::frontend::Kind as Frontend,
+    crate::{
+        frontend::Kind as Frontend,
+        localisation::Locale,
+    },
 };
 #[cfg(unix)] use xdg::BaseDirectories;
 #[cfg(windows)] use directories::ProjectDirs;
@@ -27,6 +30,7 @@ pub struct Config {
     #[serde(default)]
     pub refresh_tokens: BTreeMap<crate::IdentityProvider, String>,
     pub pj64_script_path: Option<PathBuf>,
+    pub locale: Option<Locale>,
     #[serde(default = "default_websocket_hostname")]
     pub websocket_hostname: String,
 }
@@ -112,6 +116,7 @@ impl Default for Config {
             refresh_tokens: BTreeMap::default(),
             pj64_script_path: None,
             websocket_hostname: default_websocket_hostname(),
+            locale: None,
         }
     }
 }

--- a/crate/multiworld/src/lib.rs
+++ b/crate/multiworld/src/lib.rs
@@ -78,6 +78,7 @@ use {
 #[cfg(feature = "sqlx")] use sqlx::PgPool;
 
 pub mod config;
+pub mod localisation;
 pub mod frontend;
 pub mod github;
 pub mod ws;

--- a/crate/multiworld/src/localisation.rs
+++ b/crate/multiworld/src/localisation.rs
@@ -1,0 +1,62 @@
+use {
+    serde::{
+        Deserialize,
+        Serialize,
+    }, std::fmt
+};
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, clap::ValueEnum)]
+#[clap(rename_all = "lower")]
+pub enum Locale {
+    #[default]
+    EN,
+    FR,
+}
+
+impl Locale {
+    pub const ALL: [Locale; 2] = [
+        Locale::EN,
+        Locale::FR,
+    ];
+
+    pub fn message(&self, message: Message) -> &str {
+        match message {
+            Message::InstallerReopenUAC => { //used in installer
+                match self {
+                    Locale::EN => "The installer has been reopened with admin permissions. Please continue there.",
+                    Locale::FR => "L'installateur a été ré-ouvert avec les permissions administrateur. Veuillez continuer dans la nouvelle fenêtre.",
+                }
+            },
+            Message::OpenPj64Button => { // used in gui
+                match self {
+                    Locale::EN => "Open Project64",
+                    Locale::FR => "Ouvrir Project64"
+                }
+            },
+            // TODO find a way to translate formatted text somehow
+            //Message::AMessageWithParameter(my_int, my_string) => {
+            //    match self {
+            //        Locale::EN => format!("My integer is: {} and my string is: {}",my_int,my_string).as_str(),
+            //        Locale::FR => format!("My integer is: {} and my string is: {}",my_int,my_string).as_str(),
+            //    }
+            //}
+        }
+    }
+}
+
+impl fmt::Display for Locale {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            // add local formating for display
+            Self::EN => write!(f, "English"),
+            Self::FR => write!(f, "Français"),
+        }
+    }
+}
+
+pub enum Message {
+    InstallerReopenUAC,
+    OpenPj64Button,
+    //AMessageWithParameter(i32,String),
+}
+


### PR DESCRIPTION
i added localisation logic in MHWM installer and gui
in the installer, i added a page to select the installation locale. it would be saved in the configuration file and i added args and UAC logic to keep the current flow.

in the gui i added a picklist in the settings to change the locale and save it to the config file.

To add a Localisation:
- add a Locale enum value for the locale to add
- add the locale to Locale::ALL constant for picklist to use it
- add the matching arm in the fmt implementation for the display of that locale in picklist
- for each message already matched in the `locale.message function`, add a matching arm for the newly added locale with the text to return
- in main.rs from the installer package, add a matching arm for the locale where the app is relaunched due to UAC

you can define any text to be localisable by adding a value to the Locale::Message enum and adding a translation for each existing locale in the locale.message function.

to use those localisation, use `locale.message(Locale::Message::MessageToDisplay)`

the only thing left to do is find a way to localise text that use `format!()` they currently do not work since they are allocated at runtime...im open to suggestions at this point... im not good enough with rust to know the exact workaround...

once the logic is done and working, i can implement it for english locale first, and in future PR i will add french.
then we can make a list of all known message kinda like your translation google doc you have so its easier for people to produce translation

id love your feedback on the general idea/logic i implemented and if you see any concern or have questions.