### PR TITLE
Update iced to 13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,9 +86,9 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "android-activity"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee91c0c2905bae44f84bfa4e044536541df26b7703fd0888deeb9060fcc44289"
+checksum = "ef6978589202a00cd7e118380c448a08b6ed394c3a8df3a430d0898e3a42d046"
 dependencies = [
  "android-properties",
  "bitflags 2.6.0",
@@ -100,7 +100,7 @@ dependencies = [
  "log",
  "ndk",
  "ndk-context",
- "ndk-sys",
+ "ndk-sys 0.6.0+11769913",
  "num_enum",
  "thiserror",
 ]
@@ -713,31 +713,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae85a0696e7ea3b835a453750bf002770776609115e6d25c6d2ff28a8200f7e7"
-dependencies = [
- "objc-sys",
-]
-
-[[package]]
-name = "block2"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b55663a85f33501257357e6421bb33e769d5c9ffb5ba0921c975a123e35e68"
-dependencies = [
- "block-sys",
- "objc2 0.4.1",
-]
-
-[[package]]
 name = "block2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
- "objc2 0.5.2",
+ "objc2",
 ]
 
 [[package]]
@@ -832,20 +813,6 @@ dependencies = [
 
 [[package]]
 name = "calloop"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fba7adb4dd5aa98e5553510223000e7148f621165ec5f9acd7113f6ca4995298"
-dependencies = [
- "bitflags 2.6.0",
- "log",
- "polling",
- "rustix",
- "slab",
- "thiserror",
-]
-
-[[package]]
-name = "calloop"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
@@ -860,23 +827,11 @@ dependencies = [
 
 [[package]]
 name = "calloop-wayland-source"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0ea9b9476c7fad82841a8dbb380e2eae480c21910feba80725b46931ed8f02"
-dependencies = [
- "calloop 0.12.4",
- "rustix",
- "wayland-backend",
- "wayland-client",
-]
-
-[[package]]
-name = "calloop-wayland-source"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
 dependencies = [
- "calloop 0.13.0",
+ "calloop",
  "rustix",
  "wayland-backend",
  "wayland-client",
@@ -1007,7 +962,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7f4aaa047ba3c3630b080bb9860894732ff23e2aee290a418909aa6d5df38f"
 dependencies = [
- "objc2 0.5.2",
+ "objc2",
  "objc2-app-kit",
  "objc2-foundation",
 ]
@@ -1270,19 +1225,21 @@ dependencies = [
 
 [[package]]
 name = "cosmic-text"
-version = "0.10.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75acbfb314aeb4f5210d379af45ed1ec2c98c7f1790bf57b8a4c562ac0c51b71"
+checksum = "59fd57d82eb4bfe7ffa9b1cec0c05e2fd378155b47f255a67983cb4afe0e80c2"
 dependencies = [
- "fontdb",
- "libm",
+ "bitflags 2.6.0",
+ "fontdb 0.16.2",
  "log",
  "rangemap",
+ "rayon",
  "rustc-hash 1.1.0",
- "rustybuzz 0.11.0",
+ "rustybuzz",
  "self_cell",
  "swash",
  "sys-locale",
+ "ttf-parser 0.21.1",
  "unicode-bidi",
  "unicode-linebreak",
  "unicode-script",
@@ -1699,6 +1656,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
+name = "dpi"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
+
+[[package]]
 name = "drm"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2022,21 +1985,35 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1fcfcd44ca6e90c921fee9fa665d530b21ef1327a4c1a6c5250ea44b776ada7"
 dependencies = [
- "roxmltree 0.20.0",
+ "roxmltree",
 ]
 
 [[package]]
 name = "fontdb"
-version = "0.15.0"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020e203f177c0fb250fb19455a252e838d2bbbce1f80f25ecc42402aafa8cd38"
+checksum = "b0299020c3ef3f60f526a4f64ab4a3d4ce116b1acbf24cdd22da0068e5d81dc3"
 dependencies = [
  "fontconfig-parser",
  "log",
- "memmap2 0.8.0",
+ "memmap2",
  "slotmap",
  "tinyvec",
- "ttf-parser 0.19.2",
+ "ttf-parser 0.20.0",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e32eac81c1135c1df01d4e6d4233c47ba11f6a6d07f33e0bba09d18797077770"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser 0.21.1",
 ]
 
 [[package]]
@@ -2267,16 +2244,6 @@ dependencies = [
 
 [[package]]
 name = "gif"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80792593675e051cf94a4b111980da2ba60d4a83e43e0048c5693baab3977045"
-dependencies = [
- "color_quant",
- "weezl",
-]
-
-[[package]]
-name = "gif"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fb2d69b19215e18bb912fa30f7ce15846e301408695e44e0ef719f1da9e19f2"
@@ -2436,18 +2403,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8098adac955faa2d31079b65dc48841251f69efd3ac25477903fc424362ead"
 dependencies = [
  "gl_generator",
-]
-
-[[package]]
-name = "glyphon"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a62d0338e4056db6a73221c2fb2e30619452f6ea9651bac4110f51b0f7a7581"
-dependencies = [
- "cosmic-text",
- "etagere",
- "lru",
- "wgpu",
 ]
 
 [[package]]
@@ -3044,9 +2999,9 @@ dependencies = [
 
 [[package]]
 name = "iced"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d4eb0fbbefb8c428b70680e77ed9013887b17c1d6be366b40f264f956d1a096"
+checksum = "88acfabc84ec077eaf9ede3457ffa3a104626d79022a9bf7f296093b1d60c73f"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -3059,41 +3014,56 @@ dependencies = [
 
 [[package]]
 name = "iced_core"
-version = "0.12.3"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d7e6bbd197f311ed3d8b71651876b0ce01318fde52cda862a9a7a4373c9b930"
+checksum = "0013a238275494641bf8f1732a23a808196540dc67b22ff97099c044ae4c8a1c"
 dependencies = [
  "bitflags 2.6.0",
+ "bytes",
  "glam",
  "log",
  "num-traits",
+ "once_cell",
  "palette",
- "raw-window-handle",
+ "rustc-hash 2.0.0",
  "smol_str",
  "thiserror",
  "web-time",
- "xxhash-rust",
 ]
 
 [[package]]
 name = "iced_futures"
-version = "0.12.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "370bad88fb3832cbeeb3fa6c486b4701fb7e8da32a753b3101d4ce81fc1d9497"
+checksum = "0c04a6745ba2e80f32cf01e034fd00d853aa4f4cd8b91888099cb7aaee0d5d7c"
 dependencies = [
  "futures",
  "iced_core",
  "log",
+ "rustc-hash 2.0.0",
  "tokio",
  "wasm-bindgen-futures",
  "wasm-timer",
 ]
 
 [[package]]
-name = "iced_graphics"
-version = "0.12.1"
+name = "iced_glyphon"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a044c193ef0840eacabfa05424717331d1fc5b3ecb9a89316200c75da2ba9a4"
+checksum = "41c3bb56f1820ca252bc1d0994ece33d233a55657c0c263ea7cb16895adbde82"
+dependencies = [
+ "cosmic-text",
+ "etagere",
+ "lru",
+ "rustc-hash 2.0.0",
+ "wgpu",
+]
+
+[[package]]
+name = "iced_graphics"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba25a18cfa6d5cc160aca7e1b34f73ccdff21680fa8702168c09739767b6c66f"
 dependencies = [
  "bitflags 2.6.0",
  "bytemuck",
@@ -3106,17 +3076,16 @@ dependencies = [
  "log",
  "once_cell",
  "raw-window-handle",
- "rustc-hash 1.1.0",
+ "rustc-hash 2.0.0",
  "thiserror",
  "unicode-segmentation",
- "xxhash-rust",
 ]
 
 [[package]]
 name = "iced_renderer"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c281e03001d566058f53dec9325bbe61c62da715341206d2627f57a3ecc7f69"
+checksum = "73558208059f9e622df2bf434e044ee2f838ce75201a023cf0ca3e1244f46c2a"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -3127,10 +3096,11 @@ dependencies = [
 
 [[package]]
 name = "iced_runtime"
-version = "0.12.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a79f852c01cc6d61663c94379cb3974ac3ad315a28c504e847d573e094f46822"
+checksum = "348b5b2c61c934d88ca3b0ed1ed913291e923d086a66fa288ce9669da9ef62b5"
 dependencies = [
+ "bytes",
  "iced_core",
  "iced_futures",
  "raw-window-handle",
@@ -3138,21 +3108,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "iced_style"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ea42a740915d2a5a9ff9c3aa0bca28b16e9fb660bc8f675eed71d186cadb579"
-dependencies = [
- "iced_core",
- "once_cell",
- "palette",
-]
-
-[[package]]
 name = "iced_tiny_skia"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2228781f4d381a1cbbd7905a9f077351aa8d37269094021d5d9e779f130aff"
+checksum = "c625d368284fcc43b0b36b176f76eff1abebe7959dd58bd8ce6897d641962a50"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -3160,72 +3119,65 @@ dependencies = [
  "kurbo 0.10.4",
  "log",
  "resvg",
- "rustc-hash 1.1.0",
+ "rustc-hash 2.0.0",
  "softbuffer",
  "tiny-skia",
- "xxhash-rust",
 ]
 
 [[package]]
 name = "iced_wgpu"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c243b6700452886aac1ee1987e84d9fb43b56b53fea9a1eb67713fd0fde244"
+checksum = "8194d7666004b8e947f89ab7446d323ab0b882971226c1913ef98764c9e4bbc4"
 dependencies = [
  "bitflags 2.6.0",
  "bytemuck",
  "futures",
  "glam",
- "glyphon",
  "guillotiere",
+ "iced_glyphon",
  "iced_graphics",
  "log",
  "once_cell",
  "resvg",
+ "rustc-hash 2.0.0",
+ "thiserror",
  "wgpu",
 ]
 
 [[package]]
 name = "iced_widget"
-version = "0.12.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e01b2212adecf1cb80e2267f302c0e0c263e55f97812056949199ccf9f0b908"
+checksum = "81429e1b950b0e4bca65be4c4278fea6678ea782030a411778f26fa9f8983e1d"
 dependencies = [
  "iced_renderer",
  "iced_runtime",
- "iced_style",
  "num-traits",
+ "once_cell",
+ "rustc-hash 2.0.0",
  "thiserror",
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "iced_winit"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63f66831d0e399b93f631739121a6171780d344b275d56808b9504d8ca75c7d2"
+checksum = "f44cd4e1c594b6334f409282937bf972ba14d31fedf03c23aa595d982a2fda28"
 dependencies = [
+ "iced_futures",
  "iced_graphics",
  "iced_runtime",
- "iced_style",
  "log",
+ "rustc-hash 2.0.0",
  "thiserror",
  "tracing",
+ "wasm-bindgen-futures",
  "web-sys",
  "winapi",
  "window_clipboard",
  "winit",
-]
-
-[[package]]
-name = "icrate"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d3aaff8a54577104bafdf686ff18565c3b6903ca5782a2026ef06e2c7aa319"
-dependencies = [
- "block2 0.3.0",
- "dispatch",
- "objc2 0.4.1",
 ]
 
 [[package]]
@@ -3264,7 +3216,7 @@ dependencies = [
  "byteorder",
  "color_quant",
  "exr",
- "gif 0.13.1",
+ "gif",
  "jpeg-decoder",
  "num-traits",
  "png",
@@ -3282,7 +3234,7 @@ dependencies = [
  "byteorder-lite",
  "color_quant",
  "exr",
- "gif 0.13.1",
+ "gif",
  "image-webp",
  "num-traits",
  "png",
@@ -3570,18 +3522,19 @@ dependencies = [
 
 [[package]]
 name = "kurbo"
-version = "0.9.5"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd85a5776cd9500c2e2059c8c76c3b01528566b7fcbaf8098b55a33fc298849b"
+checksum = "1618d4ebd923e97d67e7cd363d80aef35fe961005cbbbb3d2dad8bdd1bc63440"
 dependencies = [
  "arrayvec",
+ "smallvec",
 ]
 
 [[package]]
 name = "kurbo"
-version = "0.10.4"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1618d4ebd923e97d67e7cd363d80aef35fe961005cbbbb3d2dad8bdd1bc63440"
+checksum = "89234b2cc610a7dd927ebde6b41dd1a5d4214cffaef4cf1fb2195d592f92518f"
 dependencies = [
  "arrayvec",
  "smallvec",
@@ -3814,9 +3767,6 @@ name = "lru"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904"
-dependencies = [
- "hashbrown 0.14.5",
-]
 
 [[package]]
 name = "lru-cache"
@@ -3927,15 +3877,6 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "memmap2"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a5a03cefb0d953ec0be133036f14e109412fa594edc2f77227249db66cc3ed"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "memmap2"
@@ -4206,7 +4147,6 @@ dependencies = [
  "futures",
  "gio",
  "iced",
- "iced_runtime",
  "if_chain",
  "image 0.24.9",
  "itertools 0.13.0",
@@ -4251,7 +4191,6 @@ dependencies = [
  "futures",
  "gio",
  "iced",
- "iced_runtime",
  "image 0.24.9",
  "is_elevated",
  "itertools 0.13.0",
@@ -4325,7 +4264,6 @@ dependencies = [
  "futures",
  "gio",
  "iced",
- "iced_runtime",
  "image 0.24.9",
  "itertools 0.13.0",
  "multiworld",
@@ -4375,14 +4313,14 @@ dependencies = [
 
 [[package]]
 name = "ndk"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
+checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
  "bitflags 2.6.0",
  "jni-sys",
  "log",
- "ndk-sys",
+ "ndk-sys 0.6.0+11769913",
  "num_enum",
  "raw-window-handle",
  "thiserror",
@@ -4399,6 +4337,15 @@ name = "ndk-sys"
 version = "0.5.0+25.2.9519653"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+dependencies = [
+ "jni-sys",
+]
+
+[[package]]
+name = "ndk-sys"
+version = "0.6.0+11769913"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys",
 ]
@@ -4641,22 +4588,12 @@ checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
 
 [[package]]
 name = "objc2"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "559c5a40fdd30eb5e344fbceacf7595a81e242529fb4e21cf5f43fb4f11ff98d"
-dependencies = [
- "objc-sys",
- "objc2-encode 3.0.0",
-]
-
-[[package]]
-name = "objc2"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
 dependencies = [
  "objc-sys",
- "objc2-encode 4.0.3",
+ "objc2-encode",
 ]
 
 [[package]]
@@ -4666,13 +4603,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
  "bitflags 2.6.0",
- "block2 0.5.1",
+ "block2",
  "libc",
- "objc2 0.5.2",
+ "objc2",
  "objc2-core-data",
  "objc2-core-image",
  "objc2-foundation",
  "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "objc2",
+ "objc2-core-location",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-contacts"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -4682,8 +4643,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
  "bitflags 2.6.0",
- "block2 0.5.1",
- "objc2 0.5.2",
+ "block2",
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -4693,17 +4654,23 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
 dependencies = [
- "block2 0.5.1",
- "objc2 0.5.2",
+ "block2",
+ "objc2",
  "objc2-foundation",
  "objc2-metal",
 ]
 
 [[package]]
-name = "objc2-encode"
-version = "3.0.0"
+name = "objc2-core-location"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d079845b37af429bfe5dfa76e6d087d788031045b25cfc6fd898486fd9847666"
+checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-contacts",
+ "objc2-foundation",
+]
 
 [[package]]
 name = "objc2-encode"
@@ -4718,9 +4685,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
  "bitflags 2.6.0",
- "block2 0.5.1",
+ "block2",
+ "dispatch",
  "libc",
- "objc2 0.5.2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-link-presentation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -4730,8 +4710,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
  "bitflags 2.6.0",
- "block2 0.5.1",
- "objc2 0.5.2",
+ "block2",
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -4742,10 +4722,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
  "bitflags 2.6.0",
- "block2 0.5.1",
- "objc2 0.5.2",
+ "block2",
+ "objc2",
  "objc2-foundation",
  "objc2-metal",
+]
+
+[[package]]
+name = "objc2-symbols"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-foundation",
+ "objc2-link-presentation",
+ "objc2-quartz-core",
+ "objc2-symbols",
+ "objc2-uniform-type-identifiers",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-uniform-type-identifiers"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "objc2",
+ "objc2-core-location",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -5198,7 +5233,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
 dependencies = [
- "siphasher",
+ "siphasher 0.3.11",
 ]
 
 [[package]]
@@ -5207,7 +5242,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
 dependencies = [
- "siphasher",
+ "siphasher 0.3.11",
 ]
 
 [[package]]
@@ -5216,7 +5251,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
- "siphasher",
+ "siphasher 0.3.11",
 ]
 
 [[package]]
@@ -5721,12 +5756,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rctree"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b42e27ef78c35d3998403c1d26f3efd9e135d3e5121b0a4845cc5cc27547f4f"
-
-[[package]]
 name = "read-fonts"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5964,15 +5993,14 @@ checksum = "194d8e591e405d1eecf28819740abed6d719d1a2db87fc0bcdedee9a26d55560"
 
 [[package]]
 name = "resvg"
-version = "0.36.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7980f653f9a7db31acff916a262c3b78c562919263edea29bf41a056e20497"
+checksum = "944d052815156ac8fa77eaac055220e95ba0b01fa8887108ca710c03805d9051"
 dependencies = [
- "gif 0.12.0",
+ "gif",
  "jpeg-decoder",
  "log",
  "pico-args",
- "png",
  "rgb",
  "svgtypes",
  "tiny-skia",
@@ -6150,15 +6178,6 @@ checksum = "25f1877668c937b701177c349f21383c556cd3bb4ba8fa1d07fa96ccb3a8782e"
 dependencies = [
  "rocket",
  "tokio-tungstenite",
-]
-
-[[package]]
-name = "roxmltree"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862340e351ce1b271a378ec53f304a5558f7db87f3769dc655a8f6ecbb68b302"
-dependencies = [
- "xmlparser",
 ]
 
 [[package]]
@@ -6343,31 +6362,15 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "rustybuzz"
-version = "0.10.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71cd15fef9112a1f94ac64b58d1e4628192631ad6af4dc69997f995459c874e7"
+checksum = "cfb9cf8877777222e4a3bc7eb247e398b56baba500c38c1c46842431adc8b55c"
 dependencies = [
- "bitflags 1.3.2",
- "bytemuck",
- "smallvec",
- "ttf-parser 0.19.2",
- "unicode-bidi-mirroring",
- "unicode-ccc",
- "unicode-properties",
- "unicode-script",
-]
-
-[[package]]
-name = "rustybuzz"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee8fe2a8461a0854a37101fe7a1b13998d0cfa987e43248e81d2a5f4570f6fa"
-dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "bytemuck",
  "libm",
  "smallvec",
- "ttf-parser 0.20.0",
+ "ttf-parser 0.21.1",
  "unicode-bidi-mirroring",
  "unicode-ccc",
  "unicode-properties",
@@ -6413,14 +6416,14 @@ dependencies = [
 
 [[package]]
 name = "sctk-adwaita"
-version = "0.8.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70b31447ca297092c5a9916fc3b955203157b37c19ca8edde4f52e9843e602c7"
+checksum = "b6277f0217056f77f1d8f49f2950ac6c278c0d607c45f5ee99328d792ede24ec"
 dependencies = [
  "ab_glyph",
  "log",
- "memmap2 0.9.5",
- "smithay-client-toolkit 0.18.1",
+ "memmap2",
+ "smithay-client-toolkit",
  "tiny-skia",
 ]
 
@@ -6763,6 +6766,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
 name = "skrifa"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6801,50 +6810,25 @@ dependencies = [
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "922fd3eeab3bd820d76537ce8f582b1cf951eceb5475c28500c7457d9d17f53a"
-dependencies = [
- "bitflags 2.6.0",
- "calloop 0.12.4",
- "calloop-wayland-source 0.2.0",
- "cursor-icon",
- "libc",
- "log",
- "memmap2 0.9.5",
- "rustix",
- "thiserror",
- "wayland-backend",
- "wayland-client",
- "wayland-csd-frame",
- "wayland-cursor",
- "wayland-protocols 0.31.2",
- "wayland-protocols-wlr 0.2.0",
- "wayland-scanner",
- "xkeysym",
-]
-
-[[package]]
-name = "smithay-client-toolkit"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
 dependencies = [
  "bitflags 2.6.0",
- "calloop 0.13.0",
- "calloop-wayland-source 0.3.0",
+ "calloop",
+ "calloop-wayland-source",
  "cursor-icon",
  "libc",
  "log",
- "memmap2 0.9.5",
+ "memmap2",
  "rustix",
  "thiserror",
  "wayland-backend",
  "wayland-client",
  "wayland-csd-frame",
  "wayland-cursor",
- "wayland-protocols 0.32.4",
- "wayland-protocols-wlr 0.3.4",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
  "wayland-scanner",
  "xkeysym",
 ]
@@ -6856,7 +6840,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc8216eec463674a0e90f29e0ae41a4db573ec5b56b1c6c1c71615d249b6d846"
 dependencies = [
  "libc",
- "smithay-client-toolkit 0.19.2",
+ "smithay-client-toolkit",
  "wayland-backend",
 ]
 
@@ -6894,8 +6878,8 @@ dependencies = [
  "foreign-types",
  "js-sys",
  "log",
- "memmap2 0.9.5",
- "objc2 0.5.2",
+ "memmap2",
+ "objc2",
  "objc2-foundation",
  "objc2-quartz-core",
  "raw-window-handle",
@@ -7252,12 +7236,12 @@ checksum = "20e16a0f46cf5fd675563ef54f26e83e20f2366bcf027bcb3cc3ed2b98aaf2ca"
 
 [[package]]
 name = "svgtypes"
-version = "0.12.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71499ff2d42f59d26edb21369a308ede691421f79ebc0f001e2b1fd3a7c9e52"
+checksum = "794de53cc48eaabeed0ab6a3404a65f40b3e38c067e4435883a65d2aa4ca000e"
 dependencies = [
- "kurbo 0.9.5",
- "siphasher",
+ "kurbo 0.11.1",
+ "siphasher 1.0.1",
 ]
 
 [[package]]
@@ -7876,15 +7860,15 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "ttf-parser"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49d64318d8311fc2668e48b63969f4343e0a85c4a109aa8460d6672e364b8bd1"
-
-[[package]]
-name = "ttf-parser"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
+
+[[package]]
+name = "ttf-parser"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
 
 [[package]]
 name = "ttf-parser"
@@ -7975,15 +7959,15 @@ checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-bidi-mirroring"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56d12260fb92d52f9008be7e4bca09f584780eb2266dc8fecc6a192bec561694"
+checksum = "23cb788ffebc92c5948d0e997106233eeb1d8b9512f93f41651f52b6c5f5af86"
 
 [[package]]
 name = "unicode-ccc"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2520efa644f8268dce4dcd3050eaa7fc044fca03961e9998ac7e2e92b77cf1"
+checksum = "1df77b101bcc4ea3d78dafc5ad7e4f58ceffe0b2b16bf446aeb50b6cb4157656"
 
 [[package]]
 name = "unicode-ident"
@@ -8089,63 +8073,29 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "usvg"
-version = "0.36.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51daa774fe9ee5efcf7b4fec13019b8119cda764d9a8b5b06df02bb1445c656"
+checksum = "b84ea542ae85c715f07b082438a4231c3760539d902e11d093847a0b22963032"
 dependencies = [
- "base64 0.21.7",
- "log",
- "pico-args",
- "usvg-parser",
- "usvg-text-layout",
- "usvg-tree",
- "xmlwriter",
-]
-
-[[package]]
-name = "usvg-parser"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c88a5ffaa338f0e978ecf3d4e00d8f9f493e29bed0752e1a808a1db16afc40"
-dependencies = [
+ "base64 0.22.1",
  "data-url",
  "flate2",
+ "fontdb 0.18.0",
  "imagesize",
- "kurbo 0.9.5",
+ "kurbo 0.11.1",
  "log",
- "roxmltree 0.18.1",
+ "pico-args",
+ "roxmltree",
+ "rustybuzz",
  "simplecss",
- "siphasher",
- "svgtypes",
- "usvg-tree",
-]
-
-[[package]]
-name = "usvg-text-layout"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2374378cb7a3fb8f33894e0fdb8625e1bbc4f25312db8d91f862130b541593"
-dependencies = [
- "fontdb",
- "kurbo 0.9.5",
- "log",
- "rustybuzz 0.10.0",
- "unicode-bidi",
- "unicode-script",
- "unicode-vo",
- "usvg-tree",
-]
-
-[[package]]
-name = "usvg-tree"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cacb0c5edeaf3e80e5afcf5b0d4004cc1d36318befc9a7c6606507e5d0f4062"
-dependencies = [
- "rctree",
+ "siphasher 1.0.1",
  "strict-num",
  "svgtypes",
  "tiny-skia-path",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
 ]
 
 [[package]]
@@ -8383,18 +8333,6 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.31.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4"
-dependencies = [
- "bitflags 2.6.0",
- "wayland-backend",
- "wayland-client",
- "wayland-scanner",
-]
-
-[[package]]
-name = "wayland-protocols"
 version = "0.32.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b5755d77ae9040bb872a25026555ce4cb0ae75fd923e90d25fba07d81057de0"
@@ -8407,27 +8345,14 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-plasma"
-version = "0.2.0"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23803551115ff9ea9bce586860c5c5a971e360825a0309264102a9495a5ff479"
+checksum = "8a0a41a6875e585172495f7a96dfa42ca7e0213868f4f15c313f7c33221a7eff"
 dependencies = [
  "bitflags 2.6.0",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.31.2",
- "wayland-scanner",
-]
-
-[[package]]
-name = "wayland-protocols-wlr"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6"
-dependencies = [
- "bitflags 2.6.0",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols 0.31.2",
+ "wayland-protocols",
  "wayland-scanner",
 ]
 
@@ -8440,7 +8365,7 @@ dependencies = [
  "bitflags 2.6.0",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.32.4",
+ "wayland-protocols",
  "wayland-scanner",
 ]
 
@@ -8469,9 +8394,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.67"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8479,9 +8404,9 @@ dependencies = [
 
 [[package]]
 name = "web-time"
-version = "0.2.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa30049b1c872b72c89866d458eae9f20380ab280ffd1b1e18df2d3e2d98cfe0"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8587,7 +8512,7 @@ dependencies = [
  "log",
  "metal",
  "naga",
- "ndk-sys",
+ "ndk-sys 0.5.0+25.2.9519653",
  "objc",
  "once_cell",
  "parking_lot 0.12.3",
@@ -9114,47 +9039,51 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winit"
-version = "0.29.15"
+version = "0.30.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d59ad965a635657faf09c8f062badd885748428933dad8e8bdd64064d92e5ca"
+checksum = "0be9e76a1f1077e04a411f0b989cbd3c93339e1771cb41e71ac4aee95bfd2c67"
 dependencies = [
  "ahash 0.8.11",
  "android-activity",
  "atomic-waker",
  "bitflags 2.6.0",
+ "block2",
  "bytemuck",
- "calloop 0.12.4",
- "cfg_aliases 0.1.1",
+ "calloop",
+ "cfg_aliases 0.2.1",
+ "concurrent-queue",
  "core-foundation 0.9.4",
  "core-graphics 0.23.2",
  "cursor-icon",
- "icrate",
+ "dpi",
  "js-sys",
  "libc",
- "log",
- "memmap2 0.9.5",
+ "memmap2",
  "ndk",
- "ndk-sys",
- "objc2 0.4.1",
- "once_cell",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "objc2-ui-kit",
  "orbclient",
  "percent-encoding",
+ "pin-project",
  "raw-window-handle",
- "redox_syscall 0.3.5",
+ "redox_syscall 0.4.1",
  "rustix",
  "sctk-adwaita",
- "smithay-client-toolkit 0.18.1",
+ "smithay-client-toolkit",
  "smol_str",
+ "tracing",
  "unicode-segmentation",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.31.2",
+ "wayland-protocols",
  "wayland-protocols-plasma",
  "web-sys",
  "web-time",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
  "x11-dl",
  "x11rb",
  "xkbcommon-dl",
@@ -9303,22 +9232,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af4e2e2f7cba5a093896c1e150fbfe177d1883e7448200efb81d40b9d339ef26"
 
 [[package]]
-name = "xmlparser"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
-
-[[package]]
 name = "xmlwriter"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
-
-[[package]]
-name = "xxhash-rust"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a5cbf750400958819fb6178eaa83bee5cd9c29a26a40cc241df8c70fdd46984"
 
 [[package]]
 name = "xz2"

--- a/crate/multiworld-gui/Cargo.toml
+++ b/crate/multiworld-gui/Cargo.toml
@@ -24,8 +24,7 @@ clap = { version = "4", features = ["derive"] }
 dark-light = "1"
 enum-iterator = "2"
 futures = "0.3"
-iced = { version = "0.12", default-features = false, features = ["advanced", "image", "svg", "tokio"] }
-iced_runtime = "0.12"
+iced = { version = "0.13", default-features = false, features = ["advanced", "image", "svg", "tiny-skia", "tokio", "wgpu"] }
 if_chain = "1"
 image = { version = "0.24", default-features = false, features = ["ico"] } # transitive dependency of iced
 itertools = "0.13"

--- a/crate/multiworld-gui/Cargo.toml
+++ b/crate/multiworld-gui/Cargo.toml
@@ -24,7 +24,7 @@ clap = { version = "4", features = ["derive"] }
 dark-light = "1"
 enum-iterator = "2"
 futures = "0.3"
-iced = { version = "0.13", default-features = false, features = ["advanced", "image", "svg", "tiny-skia", "tokio", "wgpu"] }
+iced = { version = "0.13", default-features = false, features = ["advanced", "image", "svg", "tiny-skia", "tokio"] }
 if_chain = "1"
 image = { version = "0.24", default-features = false, features = ["ico"] } # transitive dependency of iced
 itertools = "0.13"

--- a/crate/multiworld-gui/src/everdrive.rs
+++ b/crate/multiworld-gui/src/everdrive.rs
@@ -189,7 +189,7 @@ pub(crate) struct Subscription {
 impl Recipe for Subscription {
     type Output = Message;
 
-    fn hash(&self, state: &mut iced::advanced::Hasher) {
+    fn hash(&self, state: &mut iced::advanced::subscription::Hasher) {
         TypeId::of::<Self>().hash(state);
     }
 

--- a/crate/multiworld-gui/src/login.rs
+++ b/crate/multiworld-gui/src/login.rs
@@ -87,7 +87,7 @@ pub(crate) struct Subscription(pub(crate) Provider);
 impl Recipe for Subscription {
     type Output = Message;
 
-    fn hash(&self, state: &mut iced::advanced::Hasher) {
+    fn hash(&self, state: &mut iced::advanced::subscription::Hasher) {
         TypeId::of::<Self>().hash(state);
         self.0.hash(state);
     }

--- a/crate/multiworld-gui/src/main.rs
+++ b/crate/multiworld-gui/src/main.rs
@@ -2013,7 +2013,7 @@ fn main(CliArgs { frontend }: CliArgs) -> iced::Result {
     iced::application(State::title, State::update, State::view)
         .subscription(State::subscription)
         .window(window::Settings {
-            size: Size::new(360.0, 360.0),
+            size: Size { width: 360.0, height: 360.0 },
             exit_on_close_request: false,
             icon,
             ..window::Settings::default()

--- a/crate/multiworld-gui/src/subscriptions.rs
+++ b/crate/multiworld-gui/src/subscriptions.rs
@@ -27,6 +27,7 @@ use {
         },
     },
     iced::advanced::subscription::{
+        self,
         EventStream,
         Recipe,
     },
@@ -73,7 +74,7 @@ pub(crate) struct LoggingSubscription<T> {
 impl<T: Recipe<Output = Message> + 'static> Recipe for LoggingSubscription<T> {
     type Output = Message;
 
-    fn hash(&self, state: &mut iced::advanced::subscription::Hasher) {
+    fn hash(&self, state: &mut subscription::Hasher) {
         TypeId::of::<Self>().hash(state);
         self.inner.hash(state);
     }
@@ -101,7 +102,7 @@ pub(crate) struct Connection {
 impl Recipe for Connection {
     type Output = Message;
 
-    fn hash(&self, state: &mut iced::advanced::subscription::Hasher) {
+    fn hash(&self, state: &mut subscription::Hasher) {
         TypeId::of::<Self>().hash(state);
         self.connection_id.hash(state);
     }
@@ -141,7 +142,7 @@ pub(crate) struct Listener {
 impl Recipe for Listener {
     type Output = Message;
 
-    fn hash(&self, state: &mut iced::advanced::subscription::Hasher) {
+    fn hash(&self, state: &mut subscription::Hasher) {
         TypeId::of::<Self>().hash(state);
         self.connection_id.hash(state);
     }
@@ -183,7 +184,7 @@ pub(crate) struct Client {
 impl Recipe for Client {
     type Output = Message;
 
-    fn hash(&self, state: &mut iced::advanced::subscription::Hasher) {
+    fn hash(&self, state: &mut subscription::Hasher) {
         TypeId::of::<Self>().hash(state);
     }
 

--- a/crate/multiworld-gui/src/subscriptions.rs
+++ b/crate/multiworld-gui/src/subscriptions.rs
@@ -73,7 +73,7 @@ pub(crate) struct LoggingSubscription<T> {
 impl<T: Recipe<Output = Message> + 'static> Recipe for LoggingSubscription<T> {
     type Output = Message;
 
-    fn hash(&self, state: &mut iced::advanced::Hasher) {
+    fn hash(&self, state: &mut iced::advanced::subscription::Hasher) {
         TypeId::of::<Self>().hash(state);
         self.inner.hash(state);
     }
@@ -101,7 +101,7 @@ pub(crate) struct Connection {
 impl Recipe for Connection {
     type Output = Message;
 
-    fn hash(&self, state: &mut iced::advanced::Hasher) {
+    fn hash(&self, state: &mut iced::advanced::subscription::Hasher) {
         TypeId::of::<Self>().hash(state);
         self.connection_id.hash(state);
     }
@@ -141,7 +141,7 @@ pub(crate) struct Listener {
 impl Recipe for Listener {
     type Output = Message;
 
-    fn hash(&self, state: &mut iced::advanced::Hasher) {
+    fn hash(&self, state: &mut iced::advanced::subscription::Hasher) {
         TypeId::of::<Self>().hash(state);
         self.connection_id.hash(state);
     }
@@ -183,7 +183,7 @@ pub(crate) struct Client {
 impl Recipe for Client {
     type Output = Message;
 
-    fn hash(&self, state: &mut iced::advanced::Hasher) {
+    fn hash(&self, state: &mut iced::advanced::subscription::Hasher) {
         TypeId::of::<Self>().hash(state);
     }
 

--- a/crate/multiworld-installer/Cargo.toml
+++ b/crate/multiworld-installer/Cargo.toml
@@ -37,8 +37,7 @@ dark-light = "1"
 directories = "5"
 enum-iterator = "2"
 futures = "0.3"
-iced = { version = "0.12", default-features = false, features = ["image", "tokio"] }
-iced_runtime = "0.12"
+iced = { version = "0.13", default-features = false, features = ["image", "tiny-skia", "tokio", "wgpu"] }
 image = { version = "0.24", default-features = false, features = ["ico"] } # transitive dependency of iced
 itertools = "0.13"
 lazy-regex = "3"

--- a/crate/multiworld-installer/Cargo.toml
+++ b/crate/multiworld-installer/Cargo.toml
@@ -37,7 +37,7 @@ dark-light = "1"
 directories = "5"
 enum-iterator = "2"
 futures = "0.3"
-iced = { version = "0.13", default-features = false, features = ["image", "tiny-skia", "tokio", "wgpu"] }
+iced = { version = "0.13", default-features = false, features = ["image", "tiny-skia", "tokio"] }
 image = { version = "0.24", default-features = false, features = ["ico"] } # transitive dependency of iced
 itertools = "0.13"
 lazy-regex = "3"

--- a/crate/multiworld-installer/src/main.rs
+++ b/crate/multiworld-installer/src/main.rs
@@ -717,7 +717,7 @@ impl State {
                             }
                         }
                     }
-                    return window::get_latest().and_then(window::close)
+                    return iced::exit()
                 }
             },
             Message::CopyDebugInfo => if let Page::Error(ref e, ref mut debug_info_copied) = self.page {
@@ -740,7 +740,7 @@ impl State {
             },
             Message::EmulatorPath(new_path) => if let Page::LocateEmulator { ref mut emulator_path, .. } = self.page { *emulator_path = new_path },
             Message::Error(e) => self.page = Page::Error(e, false),
-            Message::Exit => return window::get_latest().and_then(window::close),
+            Message::Exit => return iced::exit(),
             Message::InstallMultiworld => {
                 let (emulator, emulator_path, multiworld_path) = match self.page {
                     Page::LocateEmulator { emulator, ref emulator_path, ref multiworld_path, .. } |
@@ -1172,9 +1172,13 @@ fn main(Args { mut emulator }: Args) -> Result<(), MainError> {
         emulator.get_or_insert(only_emulator);
     }
     let task = if emulator.is_some() { cmd(future::ok(Message::Continue)) } else { Task::none() };
-
     Ok(iced::application(State::title, State::update, State::view)
-    .window(window::Settings { size: Size { width:400.0, height: 360.0 }, icon: Some(icon::from_file_data(include_bytes!("../../../assets/icon.ico"), Some(ImageFormat::Ico))?), ..window::Settings::default() })
-    .theme(State::theme)
-    .run_with(move ||(State::new(emulator), task))?)
+        .window(window::Settings {
+            size: Size { width: 400.0, height: 360.0 },
+            icon: Some(icon::from_file_data(include_bytes!("../../../assets/icon.ico"), Some(ImageFormat::Ico))?),
+            ..window::Settings::default()
+        })
+        .theme(State::theme)
+        .run_with(move || (State::new(emulator), task))?
+    )
 }

--- a/crate/multiworld-installer/src/main.rs
+++ b/crate/multiworld-installer/src/main.rs
@@ -27,12 +27,10 @@ use {
         Future,
     },
     iced::{
-        Application,
-        Command,
         Element,
         Length,
-        Settings,
         Size,
+        Task,
         Theme,
         clipboard,
         widget::*,
@@ -194,13 +192,13 @@ enum Message {
     SetOpenEmulator(bool),
 }
 
-fn cmd(future: impl Future<Output = Result<Message, Error>> + Send + 'static) -> Command<Message> {
-    Command::single(iced_runtime::command::Action::Future(Box::pin(async move {
+fn cmd(future: impl Future<Output = Result<Message, Error>> + Send + 'static) -> Task<Message> {
+    Task::future(Box::pin(async move {
         match future.await {
             Ok(msg) => msg,
             Err(e) => Message::Error(Arc::new(e)),
         }
-    })))
+    }))
 }
 
 #[derive(Default, Deserialize, Serialize)]
@@ -293,17 +291,9 @@ struct State {
     open_emulator: bool,
 }
 
-impl Application for State {
-    type Executor = iced::executor::Default;
-    type Message = Message;
-    type Theme = Theme;
-    type Flags = Args;
-
-    fn new(Args { mut emulator }: Args) -> (Self, Command<Message>) {
-        if let Ok(only_emulator) = all().filter(Emulator::is_supported).exactly_one() {
-            emulator.get_or_insert(only_emulator);
-        }
-        (Self {
+impl State {
+    fn new(emulator: Option<Emulator>) -> Self {
+        Self {
             http_client: reqwest::Client::builder()
                 .user_agent(concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")))
                 .use_rustls_tls()
@@ -318,11 +308,7 @@ impl Application for State {
             create_multiworld_desktop_shortcut: true,
             create_emulator_desktop_shortcut: true,
             open_emulator: true,
-        }, if emulator.is_some() {
-            cmd(future::ok(Message::Continue))
-        } else {
-            Command::none()
-        })
+        }
     }
 
     fn theme(&self) -> Theme {
@@ -345,7 +331,7 @@ impl Application for State {
 
     fn title(&self) -> String { format!("Mido's House Multiworld Installer") }
 
-    fn update(&mut self, msg: Message) -> Command<Message> {
+    fn update(&mut self, msg: Message) -> Task<Message> {
         match msg {
             Message::Back => self.page = match self.page {
                 Page::Error(_, _) | Page::Elevated | Page::SelectEmulator { .. } => unreachable!(),
@@ -410,7 +396,7 @@ impl Application for State {
                     match emulator {
                         Emulator::EverDrive => {
                             self.page = Page::EmulatorWarning { emulator, install_emulator, emulator_path: emulator_path.clone(), multiworld_path: multiworld_path.clone() };
-                            return Command::none()
+                            return Task::none()
                         }
                         #[cfg(target_os = "linux")] Emulator::Pj64V3 | Emulator::Pj64V4 => unreachable!(),
                         #[cfg(target_os = "windows")] Emulator::Pj64V3 | Emulator::Pj64V4 if !is_elevated() => {
@@ -616,7 +602,7 @@ impl Application for State {
                             match local_bizhawk_version.cmp(&required_bizhawk_version) {
                                 Less => {
                                     self.page = Page::AskBizHawkUpdate { emulator_path: emulator_path.clone(), multiworld_path: multiworld_path.clone() };
-                                    return Command::none()
+                                    return Task::none()
                                 }
                                 Equal => {}
                                 Greater => return cmd(future::err(Error::BizHawkVersionRegression)),
@@ -731,7 +717,7 @@ impl Application for State {
                             }
                         }
                     }
-                    return window::close(window::Id::MAIN)
+                    return window::get_latest().and_then(window::close)
                 }
             },
             Message::CopyDebugInfo => if let Page::Error(ref e, ref mut debug_info_copied) = self.page {
@@ -754,7 +740,7 @@ impl Application for State {
             },
             Message::EmulatorPath(new_path) => if let Page::LocateEmulator { ref mut emulator_path, .. } = self.page { *emulator_path = new_path },
             Message::Error(e) => self.page = Page::Error(e, false),
-            Message::Exit => return window::close(window::Id::MAIN),
+            Message::Exit => return window::get_latest().and_then(window::close),
             Message::InstallMultiworld => {
                 let (emulator, emulator_path, multiworld_path) = match self.page {
                     Page::LocateEmulator { emulator, ref emulator_path, ref multiworld_path, .. } |
@@ -941,7 +927,7 @@ impl Application for State {
             Message::SetInstallEmulator(new_install_emulator) => if let Page::LocateEmulator { ref mut install_emulator, .. } = self.page { *install_emulator = new_install_emulator },
             Message::SetOpenEmulator(open_emulator) => self.open_emulator = open_emulator,
         }
-        Command::none()
+        Task::none()
     }
 
     fn view(&self) -> Element<'_, Message> {
@@ -995,7 +981,7 @@ impl Application for State {
                 Some({
                     let mut row = Row::new();
                     #[cfg(target_os = "windows")] if matches!(emulator, Some(Emulator::Pj64V3 | Emulator::Pj64V4)) && !is_elevated() {
-                        row = row.push(Image::new(image::Handle::from_memory(include_bytes!("../../../assets/uac.png").to_vec())).height(Length::Fixed(20.0)));
+                        row = row.push(Image::new(image::Handle::from_bytes(include_bytes!("../../../assets/uac.png").to_vec())).height(Length::Fixed(20.0)));
                     }
                     row = row.push(Text::new("Continue"));
                     (Into::<Element<'_, Message>>::into(row.spacing(8)), emulator.is_some())
@@ -1049,7 +1035,7 @@ impl Application for State {
                 Some({
                     let mut row = Row::new();
                     #[cfg(target_os = "windows")] if emulator == Emulator::BizHawk && install_emulator && !is_elevated() {
-                        row = row.push(Image::new(image::Handle::from_memory(include_bytes!("../../../assets/uac.png").to_vec())).height(Length::Fixed(20.0)));
+                        row = row.push(Image::new(image::Handle::from_bytes(include_bytes!("../../../assets/uac.png").to_vec())).height(Length::Fixed(20.0)));
                     }
                     row = row.push(if install_emulator { Text::new(format!("Install {emulator}")) } else { Text::new("Continue") });
                     (Into::<Element<'_, Message>>::into(row.spacing(8)), !emulator_path.is_empty())
@@ -1181,13 +1167,14 @@ enum MainError {
 }
 
 #[wheel::main]
-fn main(args: Args) -> Result<(), MainError> {
-    Ok(State::run(Settings {
-        window: window::Settings {
-            size: Size { width: 400.0, height: 360.0 },
-            icon: Some(icon::from_file_data(include_bytes!("../../../assets/icon.ico"), Some(ImageFormat::Ico))?),
-            ..window::Settings::default()
-        },
-        ..Settings::with_flags(args)
-    })?)
+fn main(Args { mut emulator }: Args) -> Result<(), MainError> {
+    if let Ok(only_emulator) = all().filter(Emulator::is_supported).exactly_one() {
+        emulator.get_or_insert(only_emulator);
+    }
+    let task = if emulator.is_some() { cmd(future::ok(Message::Continue)) } else { Task::none() };
+
+    Ok(iced::application(State::title, State::update, State::view)
+    .window(window::Settings { size: Size { width:400.0, height: 360.0 }, icon: Some(icon::from_file_data(include_bytes!("../../../assets/icon.ico"), Some(ImageFormat::Ico))?), ..window::Settings::default() })
+    .theme(State::theme)
+    .run_with(move ||(State::new(emulator), task))?)
 }

--- a/crate/multiworld-updater/Cargo.toml
+++ b/crate/multiworld-updater/Cargo.toml
@@ -23,8 +23,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "std"
 clap = { version = "4", features = ["derive"] }
 dark-light = "1"
 futures = "0.3"
-iced = { version = "0.12", default-features = false, features = ["image", "tokio"] }
-iced_runtime = "0.12"
+iced = { version = "0.13", default-features = false, features = ["image", "tiny-skia", "tokio", "wgpu"] }
 image = { version = "0.24", default-features = false, features = ["ico"] } # recursive dependency of iced
 itertools = "0.13"
 multiworld = { path = "../multiworld" }

--- a/crate/multiworld-updater/Cargo.toml
+++ b/crate/multiworld-updater/Cargo.toml
@@ -23,7 +23,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "std"
 clap = { version = "4", features = ["derive"] }
 dark-light = "1"
 futures = "0.3"
-iced = { version = "0.13", default-features = false, features = ["image", "tiny-skia", "tokio", "wgpu"] }
+iced = { version = "0.13", default-features = false, features = ["image", "tiny-skia", "tokio"] }
 image = { version = "0.24", default-features = false, features = ["ico"] } # recursive dependency of iced
 itertools = "0.13"
 multiworld = { path = "../multiworld" }

--- a/crate/multiworld-updater/src/main.rs
+++ b/crate/multiworld-updater/src/main.rs
@@ -27,12 +27,10 @@ use {
         stream::TryStreamExt as _,
     },
     iced::{
-        Application,
-        Command,
         Element,
         Length,
-        Settings,
         Size,
+        Task,
         Theme,
         clipboard,
         widget::*,
@@ -178,13 +176,13 @@ impl Clone for Message {
     }
 }
 
-fn cmd(future: impl Future<Output = Result<Message, Error>> + Send + 'static) -> Command<Message> {
-    Command::single(iced_runtime::command::Action::Future(Box::pin(async move {
+fn cmd(future: impl Future<Output = Result<Message, Error>> + Send + 'static) -> Task<Message> {
+    Task::future(Box::pin(async move {
         match future.await {
             Ok(msg) => msg,
             Err(e) => Message::Error(Arc::new(e.into())),
         }
-    })))
+    }))
 }
 
 enum State {
@@ -209,32 +207,9 @@ struct App {
     state: State,
 }
 
-impl Application for App {
-    type Executor = iced::executor::Default;
-    type Message = Message;
-    type Theme = Theme;
-    type Flags = EmuArgs;
-
-    fn new(args: EmuArgs) -> (Self, Command<Message>) {
-        (App {
-            args: args.clone(),
-            state: State::WaitExit,
-        }, cmd(async move {
-            let mut system = sysinfo::System::default();
-            match args {
-                EmuArgs::BizHawk { mw_pid, bizhawk_pid, .. } => {
-                    while system.refresh_processes_specifics(ProcessesToUpdate::Some(&[mw_pid, bizhawk_pid]), ProcessRefreshKind::default()) > 0 {
-                        sleep(Duration::from_secs(1)).await;
-                    }
-                }
-                EmuArgs::EverDrive { pid, .. } | EmuArgs::Pj64 { pid, .. } => {
-                    while system.refresh_processes_specifics(ProcessesToUpdate::Some(&[pid]), ProcessRefreshKind::default()) > 0 {
-                        sleep(Duration::from_secs(1)).await;
-                    }
-                }
-            }
-            Ok(Message::Exited)
-        }))
+impl App {
+    fn new(args: EmuArgs) -> Self {
+        Self { args, state: State::WaitExit }
     }
 
     fn title(&self) -> String { format!("updating Mido's House Multiworld…") }
@@ -257,7 +232,7 @@ impl Application for App {
         }
     }
 
-    fn update(&mut self, msg: Message) -> Command<Message> {
+    fn update(&mut self, msg: Message) -> Task<Message> {
         match msg {
             Message::Error(e) => self.state = State::Error(e, false),
             Message::CopyDebugInfo => if let State::Error(ref e, ref mut debug_info_copied) = self.state {
@@ -485,7 +460,7 @@ impl Application for App {
             },
             Message::Done => {
                 self.state = State::Done;
-                return window::close(window::Id::MAIN)
+                return window::get_latest().and_then(window::close)
             }
             Message::DiscordInvite => if let Err(e) = open("https://discord.gg/BGRrKKn") {
                 self.state = State::Error(Arc::new(Err::<Never, _>(e).at_unknown().never_unwrap_err().into()), false);
@@ -507,7 +482,7 @@ impl Application for App {
             },
             Message::Cloned => self.state = State::Error(Arc::new(Error::Cloned), false),
         }
-        Command::none()
+        Task::none()
     }
 
     fn view(&self) -> Element<'_, Message> {
@@ -648,14 +623,33 @@ enum MainError {
 #[wheel::main]
 fn main(args: Args) -> Result<(), MainError> {
     match args {
-        Args::Emu(args) => Ok(App::run(Settings {
-            window: window::Settings {
-                size: Size { width: 320.0, height: 240.0 },
-                icon: Some(icon::from_file_data(include_bytes!("../../../assets/icon.ico"), Some(ImageFormat::Ico))?),
-                ..window::Settings::default()
-            },
-            ..Settings::with_flags(args)
-        })?),
+        Args::Emu(args) => Ok(
+            iced::application(App::title, App::update, App::view)
+                .window(window::Settings { 
+                    size: Size::new(360.0, 360.0),
+                    icon: Some(icon::from_file_data(include_bytes!("../../../assets/icon.ico"), Some(ImageFormat::Ico))?),
+                    ..window::Settings::default()}
+                )
+                .theme(App::theme)
+                .run_with(||(App::new(args.clone()),
+                cmd(async move {
+                    let mut system = sysinfo::System::default();
+                    match args {
+                        EmuArgs::BizHawk { mw_pid, bizhawk_pid, .. } => {
+                            while system.refresh_processes_specifics(ProcessesToUpdate::Some(&[mw_pid, bizhawk_pid]), ProcessRefreshKind::default()) > 0 {
+                                sleep(Duration::from_secs(1)).await;
+                            }
+                        }
+                        EmuArgs::EverDrive { pid, .. } | EmuArgs::Pj64 { pid, .. } => {
+                            while system.refresh_processes_specifics(ProcessesToUpdate::Some(&[pid]), ProcessRefreshKind::default()) > 0 {
+                                sleep(Duration::from_secs(1)).await;
+                            }
+                        }
+                    }
+                    Ok(Message::Exited)
+                })
+            ))?
+        ),
         Args::Pj64Script { src, dst } => match pj64script(&src, &dst) {
             Ok(()) => Ok(()),
             Err(e) => {


### PR DESCRIPTION
update iced dependency to 13.0
[This is the release note](https://github.com/iced-rs/iced/releases/tag/0.13.0), but I'll try to explain the changes required as best as I can:

- `iced::advanced::Hasher` was moved to `iced::advanced::Subscription::Hasher`.
- `image::Handle::from_memory` was renamed to `image::Handle::from_bytes`.
- `Command API` was changed to `Task API` which resulted in changing `Command` to `Task`. For most of the uses, not much was required, but I do have some concerns about the `cmd()` function that is used in the installer/updater/gui since I haven't worked a lot with the Command/Task API.
- there is no more Application implementation. I think they changed it so it is easier to understand and build small apps. I had to remove the Application implementation and change a bit the way the apps are launched. But in short, they replaced the `Application::run` with `iced::application().run_with()` and added a bunch of builders to set the settings and default state for each app.
- They removed the `Id` parameter from the `CloseRequested` event and changed the `Id` structure (the `Id::MAIN` constant was removed), so I had to find another way to close the window.
- seems like `iced_runtime` was no longer used after my changes so I removed it.
- I had to add `wgpu` to the feature flags since the app was no longer rendered correctly after I bumped the version. I saw that `tiny-skia` was used as a fallback in the doc, so I added it too just in case.

That's pretty much it, so my biggest concern is the changes to `cmd` functions that are related to the `Task` API switch.

I haven't fully tested all the ui apps yet, but they seem to work as intended. I'll try to do some more testing.
I think they also changed the default styling a bit, so there might be some minor styling differences, the only ones i found are the radio buttons that are a bit smaller (the left app is iced 13.0), and some padding/margin.

![image](https://github.com/user-attachments/assets/2a3fa766-d70d-41b7-bfa2-23f1491dd245)


This version introduced the `Stack` widget, and I intended to use it to make a searchable `picklist` for the room name selection (since `combobox` menu was a bit janky when updating the room list in real-time). most of the work for that feature is already in progress on my side. I realized that this version bump was bigger than I anticipated. so I preferred not to include those changes as well.

leaving this as a draft until you have time to check it first. thanks