### PR TITLE
Expanded Flashcart and Wii VC Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ version = "0.26.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "962e462a6778bf5c3d4f169f7b76032de7d443999d9dd02ee9ec68063259b2a9"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -687,6 +687,26 @@ name = "binascii"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "383d29d513d8764dcdc42ea295d979eb99c3c9f00607b3692cf68a431f7dca72"
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.10.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.1",
+ "shlex",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "bit-set"
@@ -958,6 +978,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "cfg-expr"
 version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -991,6 +1020,17 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -4734,6 +4774,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -5442,7 +5491,7 @@ dependencies = [
  "futures",
  "github-app-auth",
  "if_chain",
- "itertools",
+ "itertools 0.14.0",
  "log-lock",
  "multiworld-derive",
  "nonempty-collections",
@@ -5479,7 +5528,7 @@ dependencies = [
  "clap",
  "crossterm",
  "futures",
- "itertools",
+ "itertools 0.14.0",
  "multiworld",
  "ootr-utils",
  "serde_json_path_to_error",
@@ -5510,7 +5559,7 @@ dependencies = [
  "async-proto",
  "chrono",
  "directories",
- "itertools",
+ "itertools 0.14.0",
  "libc",
  "multiworld",
  "multiworld-derive",
@@ -5529,7 +5578,7 @@ dependencies = [
 name = "multiworld-derive"
 version = "17.1.5"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "lazy-regex",
  "proc-macro2",
  "quote",
@@ -5551,9 +5600,10 @@ dependencies = [
  "iced",
  "if_chain",
  "image",
- "itertools",
+ "itertools 0.14.0",
  "log-lock",
  "multiworld",
+ "n64flashcart",
  "num-traits",
  "oauth2",
  "once_cell",
@@ -5598,7 +5648,7 @@ dependencies = [
  "if_chain",
  "image",
  "is_elevated",
- "itertools",
+ "itertools 0.14.0",
  "kuchiki",
  "lazy-regex",
  "mslnk",
@@ -5631,7 +5681,7 @@ version = "17.1.5"
 dependencies = [
  "clap",
  "futures",
- "itertools",
+ "itertools 0.14.0",
  "lazy-regex",
  "semver",
  "sha2",
@@ -5655,7 +5705,7 @@ dependencies = [
  "github-app-auth",
  "graphql_client",
  "gres",
- "itertools",
+ "itertools 0.14.0",
  "lazy-regex",
  "log-lock",
  "multiworld",
@@ -5704,7 +5754,7 @@ dependencies = [
  "futures",
  "iced",
  "image",
- "itertools",
+ "itertools 0.14.0",
  "multiworld",
  "open",
  "reqwest 0.13.1",
@@ -5754,6 +5804,14 @@ name = "mutate_once"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d2233c9842d08cfe13f9eac96e207ca6a2ea10b80259ebe8ad0268be27d2af"
+
+[[package]]
+name = "n64flashcart"
+version = "0.1.0"
+source = "git+https://github.com/mracsys/n64usb#21b9e3d25ff775e71c9dbf0b34de55f93b97520c"
+dependencies = [
+ "bindgen",
+]
 
 [[package]]
 name = "naga"
@@ -6440,7 +6498,7 @@ dependencies = [
  "directories",
  "enum-iterator",
  "gix",
- "itertools",
+ "itertools 0.14.0",
  "lazy-regex",
  "semver",
  "serde",
@@ -6505,7 +6563,7 @@ dependencies = [
  "enum-iterator",
  "futures",
  "image",
- "itertools",
+ "itertools 0.14.0",
  "ootr",
  "oottracker-derive",
  "reqwest 0.12.28",
@@ -6526,7 +6584,7 @@ version = "0.7.4"
 source = "git+https://github.com/fenhl/oottracker?branch=mw#ee24381752d3ec42445f2b5e521789eeaa21108e"
 dependencies = [
  "convert_case 0.8.0",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -6990,6 +7048,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7082,7 +7150,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -7368,7 +7436,7 @@ dependencies = [
  "built",
  "cfg-if",
  "interpolate_name",
- "itertools",
+ "itertools 0.14.0",
  "libc",
  "libfuzzer-sys",
  "log",
@@ -10690,7 +10758,7 @@ dependencies = [
  "futures",
  "gio",
  "iced",
- "itertools",
+ "itertools 0.14.0",
  "reqwest 0.13.1",
  "rocket",
  "rocket-util",
@@ -10710,7 +10778,7 @@ name = "wheel-derive"
 version = "0.15.3"
 source = "git+https://github.com/fenhl/wheel#d1460622d5ba4b8529e8c2d97f8db664b2738624"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5808,7 +5808,7 @@ checksum = "13d2233c9842d08cfe13f9eac96e207ca6a2ea10b80259ebe8ad0268be27d2af"
 [[package]]
 name = "n64flashcart"
 version = "1.2.2"
-source = "git+https://github.com/mracsys/n64usb?rev=5fdff6699183a6fe7638ab595bf999f2b0bde183#5fdff6699183a6fe7638ab595bf999f2b0bde183"
+source = "git+https://github.com/mracsys/n64usb?rev=047326569ede0730752ddeb0da0955e8f9e27e85#047326569ede0730752ddeb0da0955e8f9e27e85"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5808,7 +5808,7 @@ checksum = "13d2233c9842d08cfe13f9eac96e207ca6a2ea10b80259ebe8ad0268be27d2af"
 [[package]]
 name = "n64flashcart"
 version = "0.1.0"
-source = "git+https://github.com/mracsys/n64usb#f5bbc308a559925be7fe064d8939e2c5f39ae132"
+source = "git+https://github.com/mracsys/n64usb#690a81731d989a0ebadb83bc5287cef3d3120db9"
 dependencies = [
  "bindgen",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5808,7 +5808,7 @@ checksum = "13d2233c9842d08cfe13f9eac96e207ca6a2ea10b80259ebe8ad0268be27d2af"
 [[package]]
 name = "n64flashcart"
 version = "0.1.0"
-source = "git+https://github.com/mracsys/n64usb#423bb574c4bf53ea0ad0686095042e2b0c6f7803"
+source = "git+https://github.com/mracsys/n64usb#ea4f1d46a068494773185ef8a1af234163e3da15"
 dependencies = [
  "bindgen",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5807,8 +5807,8 @@ checksum = "13d2233c9842d08cfe13f9eac96e207ca6a2ea10b80259ebe8ad0268be27d2af"
 
 [[package]]
 name = "n64flashcart"
-version = "1.3.3"
-source = "git+https://github.com/mracsys/n64usb?rev=33574d1882a35606f0e93199fabc2cc11aad5db3#33574d1882a35606f0e93199fabc2cc11aad5db3"
+version = "1.4.1"
+source = "git+https://github.com/mracsys/n64usb?rev=62ba806f8ed7e0ded2e090b31e23c32c12d4663a#62ba806f8ed7e0ded2e090b31e23c32c12d4663a"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5807,8 +5807,8 @@ checksum = "13d2233c9842d08cfe13f9eac96e207ca6a2ea10b80259ebe8ad0268be27d2af"
 
 [[package]]
 name = "n64flashcart"
-version = "1.3.2"
-source = "git+https://github.com/mracsys/n64usb?rev=1cf73fd9ead7cf45227867b521da8e624189f2b2#1cf73fd9ead7cf45227867b521da8e624189f2b2"
+version = "1.3.3"
+source = "git+https://github.com/mracsys/n64usb?rev=33574d1882a35606f0e93199fabc2cc11aad5db3#33574d1882a35606f0e93199fabc2cc11aad5db3"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5807,8 +5807,8 @@ checksum = "13d2233c9842d08cfe13f9eac96e207ca6a2ea10b80259ebe8ad0268be27d2af"
 
 [[package]]
 name = "n64flashcart"
-version = "1.2.2"
-source = "git+https://github.com/mracsys/n64usb?rev=047326569ede0730752ddeb0da0955e8f9e27e85#047326569ede0730752ddeb0da0955e8f9e27e85"
+version = "1.3.2"
+source = "git+https://github.com/mracsys/n64usb?rev=1cf73fd9ead7cf45227867b521da8e624189f2b2#1cf73fd9ead7cf45227867b521da8e624189f2b2"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5808,7 +5808,7 @@ checksum = "13d2233c9842d08cfe13f9eac96e207ca6a2ea10b80259ebe8ad0268be27d2af"
 [[package]]
 name = "n64flashcart"
 version = "0.1.0"
-source = "git+https://github.com/mracsys/n64usb#690a81731d989a0ebadb83bc5287cef3d3120db9"
+source = "git+https://github.com/mracsys/n64usb#78f8ccadba034a51207bb961add279a302f7278b"
 dependencies = [
  "bindgen",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5807,8 +5807,8 @@ checksum = "13d2233c9842d08cfe13f9eac96e207ca6a2ea10b80259ebe8ad0268be27d2af"
 
 [[package]]
 name = "n64flashcart"
-version = "1.2.0"
-source = "git+https://github.com/mracsys/n64usb?rev=6ca2863a4fdc5f00718947ab6f478d31d9497ec5#6ca2863a4fdc5f00718947ab6f478d31d9497ec5"
+version = "1.2.1"
+source = "git+https://github.com/mracsys/n64usb?rev=4a53fb30425222e9224b8f0c5367ea9b2d2c29a1#4a53fb30425222e9224b8f0c5367ea9b2d2c29a1"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5808,7 +5808,7 @@ checksum = "13d2233c9842d08cfe13f9eac96e207ca6a2ea10b80259ebe8ad0268be27d2af"
 [[package]]
 name = "n64flashcart"
 version = "0.1.0"
-source = "git+https://github.com/mracsys/n64usb#ea4f1d46a068494773185ef8a1af234163e3da15"
+source = "git+https://github.com/mracsys/n64usb#f5bbc308a559925be7fe064d8939e2c5f39ae132"
 dependencies = [
  "bindgen",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5807,8 +5807,8 @@ checksum = "13d2233c9842d08cfe13f9eac96e207ca6a2ea10b80259ebe8ad0268be27d2af"
 
 [[package]]
 name = "n64flashcart"
-version = "1.4.1"
-source = "git+https://github.com/mracsys/n64usb?rev=62ba806f8ed7e0ded2e090b31e23c32c12d4663a#62ba806f8ed7e0ded2e090b31e23c32c12d4663a"
+version = "1.4.2"
+source = "git+https://github.com/mracsys/n64usb?rev=854a13ee87df6eba0e7f74af11e403d96e6a0992#854a13ee87df6eba0e7f74af11e403d96e6a0992"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5807,8 +5807,8 @@ checksum = "13d2233c9842d08cfe13f9eac96e207ca6a2ea10b80259ebe8ad0268be27d2af"
 
 [[package]]
 name = "n64flashcart"
-version = "2.0.1"
-source = "git+https://github.com/mracsys/n64usb?rev=b4fa9ab91c4945e1a0e9dbd97ca5947b1590b54b#b4fa9ab91c4945e1a0e9dbd97ca5947b1590b54b"
+version = "2.0.2"
+source = "git+https://github.com/mracsys/n64usb?rev=477c09d51d37b49eb1a4a85261177d19d7061e43#477c09d51d37b49eb1a4a85261177d19d7061e43"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5807,8 +5807,8 @@ checksum = "13d2233c9842d08cfe13f9eac96e207ca6a2ea10b80259ebe8ad0268be27d2af"
 
 [[package]]
 name = "n64flashcart"
-version = "1.2.1"
-source = "git+https://github.com/mracsys/n64usb?rev=4a53fb30425222e9224b8f0c5367ea9b2d2c29a1#4a53fb30425222e9224b8f0c5367ea9b2d2c29a1"
+version = "1.2.2"
+source = "git+https://github.com/mracsys/n64usb?rev=5fdff6699183a6fe7638ab595bf999f2b0bde183#5fdff6699183a6fe7638ab595bf999f2b0bde183"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5808,7 +5808,7 @@ checksum = "13d2233c9842d08cfe13f9eac96e207ca6a2ea10b80259ebe8ad0268be27d2af"
 [[package]]
 name = "n64flashcart"
 version = "0.1.0"
-source = "git+https://github.com/mracsys/n64usb#21b9e3d25ff775e71c9dbf0b34de55f93b97520c"
+source = "git+https://github.com/mracsys/n64usb#423bb574c4bf53ea0ad0686095042e2b0c6f7803"
 dependencies = [
  "bindgen",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -961,9 +961,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.53"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755d2fce177175ffca841e9a06afdb2c4ab0f593d53b4dee48147dfaade85932"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2264,9 +2264,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
@@ -5807,10 +5807,11 @@ checksum = "13d2233c9842d08cfe13f9eac96e207ca6a2ea10b80259ebe8ad0268be27d2af"
 
 [[package]]
 name = "n64flashcart"
-version = "0.1.0"
-source = "git+https://github.com/mracsys/n64usb#78f8ccadba034a51207bb961add279a302f7278b"
+version = "1.2.0"
+source = "git+https://github.com/mracsys/n64usb?rev=6ca2863a4fdc5f00718947ab6f478d31d9497ec5#6ca2863a4fdc5f00718947ab6f478d31d9497ec5"
 dependencies = [
  "bindgen",
+ "cc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5807,8 +5807,8 @@ checksum = "13d2233c9842d08cfe13f9eac96e207ca6a2ea10b80259ebe8ad0268be27d2af"
 
 [[package]]
 name = "n64flashcart"
-version = "1.4.2"
-source = "git+https://github.com/mracsys/n64usb?rev=854a13ee87df6eba0e7f74af11e403d96e6a0992#854a13ee87df6eba0e7f74af11e403d96e6a0992"
+version = "2.0.1"
+source = "git+https://github.com/mracsys/n64usb?rev=b4fa9ab91c4945e1a0e9dbd97ca5947b1590b54b#b4fa9ab91c4945e1a0e9dbd97ca5947b1590b54b"
 dependencies = [
  "bindgen",
  "cc",

--- a/crate/multiworld-gui/Cargo.toml
+++ b/crate/multiworld-gui/Cargo.toml
@@ -33,6 +33,7 @@ image = { version = "0.25", default-features = false, features = ["ico"] }
 itertools = "0.14"
 log-lock = { git = "https://github.com/fenhl/log-lock" }
 multiworld = { path = "../multiworld" }
+n64flashcart = { git = "https://github.com/mracsys/n64usb" }
 num-traits = { version = "0.2.19", default-features = false }
 oauth2 = "4"
 once_cell = "1"

--- a/crate/multiworld-gui/Cargo.toml
+++ b/crate/multiworld-gui/Cargo.toml
@@ -33,7 +33,7 @@ image = { version = "0.25", default-features = false, features = ["ico"] }
 itertools = "0.14"
 log-lock = { git = "https://github.com/fenhl/log-lock" }
 multiworld = { path = "../multiworld" }
-n64flashcart = { git = "https://github.com/mracsys/n64usb", rev = "33574d1882a35606f0e93199fabc2cc11aad5db3" }
+n64flashcart = { git = "https://github.com/mracsys/n64usb", rev = "62ba806f8ed7e0ded2e090b31e23c32c12d4663a" }
 num-traits = { version = "0.2.19", default-features = false }
 oauth2 = "4"
 once_cell = "1"

--- a/crate/multiworld-gui/Cargo.toml
+++ b/crate/multiworld-gui/Cargo.toml
@@ -33,7 +33,7 @@ image = { version = "0.25", default-features = false, features = ["ico"] }
 itertools = "0.14"
 log-lock = { git = "https://github.com/fenhl/log-lock" }
 multiworld = { path = "../multiworld" }
-n64flashcart = { git = "https://github.com/mracsys/n64usb", rev = "047326569ede0730752ddeb0da0955e8f9e27e85" }
+n64flashcart = { git = "https://github.com/mracsys/n64usb", rev = "1cf73fd9ead7cf45227867b521da8e624189f2b2" }
 num-traits = { version = "0.2.19", default-features = false }
 oauth2 = "4"
 once_cell = "1"

--- a/crate/multiworld-gui/Cargo.toml
+++ b/crate/multiworld-gui/Cargo.toml
@@ -33,7 +33,7 @@ image = { version = "0.25", default-features = false, features = ["ico"] }
 itertools = "0.14"
 log-lock = { git = "https://github.com/fenhl/log-lock" }
 multiworld = { path = "../multiworld" }
-n64flashcart = { git = "https://github.com/mracsys/n64usb" }
+n64flashcart = { git = "https://github.com/mracsys/n64usb", rev = "6ca2863a4fdc5f00718947ab6f478d31d9497ec5" }
 num-traits = { version = "0.2.19", default-features = false }
 oauth2 = "4"
 once_cell = "1"

--- a/crate/multiworld-gui/Cargo.toml
+++ b/crate/multiworld-gui/Cargo.toml
@@ -33,7 +33,7 @@ image = { version = "0.25", default-features = false, features = ["ico"] }
 itertools = "0.14"
 log-lock = { git = "https://github.com/fenhl/log-lock" }
 multiworld = { path = "../multiworld" }
-n64flashcart = { git = "https://github.com/mracsys/n64usb", rev = "1cf73fd9ead7cf45227867b521da8e624189f2b2" }
+n64flashcart = { git = "https://github.com/mracsys/n64usb", rev = "33574d1882a35606f0e93199fabc2cc11aad5db3" }
 num-traits = { version = "0.2.19", default-features = false }
 oauth2 = "4"
 once_cell = "1"

--- a/crate/multiworld-gui/Cargo.toml
+++ b/crate/multiworld-gui/Cargo.toml
@@ -33,7 +33,7 @@ image = { version = "0.25", default-features = false, features = ["ico"] }
 itertools = "0.14"
 log-lock = { git = "https://github.com/fenhl/log-lock" }
 multiworld = { path = "../multiworld" }
-n64flashcart = { git = "https://github.com/mracsys/n64usb", rev = "6ca2863a4fdc5f00718947ab6f478d31d9497ec5" }
+n64flashcart = { git = "https://github.com/mracsys/n64usb", rev = "4a53fb30425222e9224b8f0c5367ea9b2d2c29a1" }
 num-traits = { version = "0.2.19", default-features = false }
 oauth2 = "4"
 once_cell = "1"

--- a/crate/multiworld-gui/Cargo.toml
+++ b/crate/multiworld-gui/Cargo.toml
@@ -33,7 +33,7 @@ image = { version = "0.25", default-features = false, features = ["ico"] }
 itertools = "0.14"
 log-lock = { git = "https://github.com/fenhl/log-lock" }
 multiworld = { path = "../multiworld" }
-n64flashcart = { git = "https://github.com/mracsys/n64usb", rev = "854a13ee87df6eba0e7f74af11e403d96e6a0992" }
+n64flashcart = { git = "https://github.com/mracsys/n64usb", rev = "b4fa9ab91c4945e1a0e9dbd97ca5947b1590b54b" }
 num-traits = { version = "0.2.19", default-features = false }
 oauth2 = "4"
 once_cell = "1"

--- a/crate/multiworld-gui/Cargo.toml
+++ b/crate/multiworld-gui/Cargo.toml
@@ -33,7 +33,7 @@ image = { version = "0.25", default-features = false, features = ["ico"] }
 itertools = "0.14"
 log-lock = { git = "https://github.com/fenhl/log-lock" }
 multiworld = { path = "../multiworld" }
-n64flashcart = { git = "https://github.com/mracsys/n64usb", rev = "b4fa9ab91c4945e1a0e9dbd97ca5947b1590b54b" }
+n64flashcart = { git = "https://github.com/mracsys/n64usb", rev = "477c09d51d37b49eb1a4a85261177d19d7061e43" }
 num-traits = { version = "0.2.19", default-features = false }
 oauth2 = "4"
 once_cell = "1"

--- a/crate/multiworld-gui/Cargo.toml
+++ b/crate/multiworld-gui/Cargo.toml
@@ -33,7 +33,7 @@ image = { version = "0.25", default-features = false, features = ["ico"] }
 itertools = "0.14"
 log-lock = { git = "https://github.com/fenhl/log-lock" }
 multiworld = { path = "../multiworld" }
-n64flashcart = { git = "https://github.com/mracsys/n64usb", rev = "5fdff6699183a6fe7638ab595bf999f2b0bde183" }
+n64flashcart = { git = "https://github.com/mracsys/n64usb", rev = "047326569ede0730752ddeb0da0955e8f9e27e85" }
 num-traits = { version = "0.2.19", default-features = false }
 oauth2 = "4"
 once_cell = "1"

--- a/crate/multiworld-gui/Cargo.toml
+++ b/crate/multiworld-gui/Cargo.toml
@@ -33,7 +33,7 @@ image = { version = "0.25", default-features = false, features = ["ico"] }
 itertools = "0.14"
 log-lock = { git = "https://github.com/fenhl/log-lock" }
 multiworld = { path = "../multiworld" }
-n64flashcart = { git = "https://github.com/mracsys/n64usb", rev = "62ba806f8ed7e0ded2e090b31e23c32c12d4663a" }
+n64flashcart = { git = "https://github.com/mracsys/n64usb", rev = "854a13ee87df6eba0e7f74af11e403d96e6a0992" }
 num-traits = { version = "0.2.19", default-features = false }
 oauth2 = "4"
 once_cell = "1"

--- a/crate/multiworld-gui/Cargo.toml
+++ b/crate/multiworld-gui/Cargo.toml
@@ -33,7 +33,7 @@ image = { version = "0.25", default-features = false, features = ["ico"] }
 itertools = "0.14"
 log-lock = { git = "https://github.com/fenhl/log-lock" }
 multiworld = { path = "../multiworld" }
-n64flashcart = { git = "https://github.com/mracsys/n64usb", rev = "4a53fb30425222e9224b8f0c5367ea9b2d2c29a1" }
+n64flashcart = { git = "https://github.com/mracsys/n64usb", rev = "5fdff6699183a6fe7638ab595bf999f2b0bde183" }
 num-traits = { version = "0.2.19", default-features = false }
 oauth2 = "4"
 once_cell = "1"

--- a/crate/multiworld-gui/build.rs
+++ b/crate/multiworld-gui/build.rs
@@ -10,12 +10,6 @@ use {
 };
 
 fn main() -> io::Result<()> {
-    #[cfg(target_os = "linux")]
-    println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN");
-
-    #[cfg(target_os = "macos")]
-    println!("cargo:rustc-link-arg=-Wl,-rpath,@executable_path");
-
     if env::var_os("CARGO_CFG_WINDOWS").is_some() {
         WindowsResource::new()
             .set_icon("../../assets/icon.ico")

--- a/crate/multiworld-gui/build.rs
+++ b/crate/multiworld-gui/build.rs
@@ -10,6 +10,12 @@ use {
 };
 
 fn main() -> io::Result<()> {
+    #[cfg(target_os = "linux")]
+    println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN");
+
+    #[cfg(target_os = "macos")]
+    println!("cargo:rustc-link-arg=-Wl,-rpath,@executable_path");
+
     if env::var_os("CARGO_CFG_WINDOWS").is_some() {
         WindowsResource::new()
             .set_icon("../../assets/icon.ico")

--- a/crate/multiworld-gui/src/everdrive.rs
+++ b/crate/multiworld-gui/src/everdrive.rs
@@ -52,6 +52,7 @@ use {
     tokio_serial::{
         SerialPortBuilderExt as _,
         SerialStream,
+        SerialPortType::UsbPort,
     },
     multiworld::{
         Filename,
@@ -251,19 +252,26 @@ impl Recipe for Subscription {
                         if log {
                             let _ = lock!(log = crate::LOG; writeln!(&*log, "{} EverDrive: attempting to connect to {port_info:?}", Utc::now().format("%Y-%m-%d %H:%M:%S")));
                         }
-                        match connect_to_port(&port_info, log).await {
-                            Ok(resp) => {
-                                if log {
-                                    let _ = lock!(log = crate::LOG; writeln!(&*log, "{} EverDrive: connection successful: {resp:?}", Utc::now().format("%Y-%m-%d %H:%M:%S")));
+                        // Filter serial adapters only to those known to be used by Everdrives.
+                        // This prevents the extension from locking the device for other plugins.
+                        if let UsbPort(ref usb_info) = port_info.port_type {
+                            if usb_info.vid == 0x0403 && usb_info.pid == 0x6001
+                            && usb_info.product.as_deref().is_some_and(|p| p.contains("FT245R USB FIFO")) {
+                                match connect_to_port(&port_info, log).await {
+                                    Ok(resp) => {
+                                        if log {
+                                            let _ = lock!(log = crate::LOG; writeln!(&*log, "{} EverDrive: connection successful: {resp:?}", Utc::now().format("%Y-%m-%d %H:%M:%S")));
+                                        }
+                                        response = Some(resp);
+                                        break
+                                    }
+                                    Err(e) => {
+                                        if log {
+                                            let _ = lock!(log = crate::LOG; writeln!(&*log, "{} EverDrive: connection failed: {e:?}", Utc::now().format("%Y-%m-%d %H:%M:%S")));
+                                        }
+                                        errors.push((port_info, e));
+                                    }
                                 }
-                                response = Some(resp);
-                                break
-                            }
-                            Err(e) => {
-                                if log {
-                                    let _ = lock!(log = crate::LOG; writeln!(&*log, "{} EverDrive: connection failed: {e:?}", Utc::now().format("%Y-%m-%d %H:%M:%S")));
-                                }
-                                errors.push((port_info, e));
                             }
                         }
                     }

--- a/crate/multiworld-gui/src/flashcart.rs
+++ b/crate/multiworld-gui/src/flashcart.rs
@@ -1,0 +1,52 @@
+use {
+    crate::Message, futures::stream::{
+            self,
+            Stream,
+            StreamExt as _,
+    }, iced::advanced::subscription::{
+        EventStream,
+        Recipe,
+    }, n64flashcart, std::{
+        any::TypeId,
+        hash::Hash as _,
+        pin::Pin, sync::Arc,
+    }
+};
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum Error {
+    #[error("N64 reported as world 0")]
+    NotFound,
+}
+
+pub(crate) struct Subscription {
+//    pub(crate) log: bool,
+}
+
+impl Recipe for Subscription {
+    type Output = Message;
+
+    fn hash(&self, state: &mut iced::advanced::subscription::Hasher) {
+        TypeId::of::<Self>().hash(state);
+    }
+
+    fn stream(self: Box<Self>, _: EventStream) -> Pin<Box<dyn Stream<Item = Message> + Send>> {
+        println!("Flashcart stream");
+
+        stream::try_unfold(0, |_state| async move {
+            let status = n64flashcart::find();
+            if status == n64flashcart::DeviceError::CARTFINDFAIL {
+                println!("Flashcart disconnected, resetting");
+                n64flashcart::initialize();
+                return Err(Error::NotFound)
+            } else if status != n64flashcart::DeviceError::OK {
+                // Flashcart not found, wait and retry
+                // sleep(Duration(1));
+                println!("Flashcart not found");
+            } else {
+                println!("Flashcart found, {}", n64flashcart::cart_type_to_str(n64flashcart::get_cart()));
+            }
+            return Ok(None)
+        }).map(|res| res.unwrap_or_else(|e: Error | Message::FrontendSubscriptionError(Arc::new(e.into())))).boxed()
+    }
+}

--- a/crate/multiworld-gui/src/flashcart.rs
+++ b/crate/multiworld-gui/src/flashcart.rs
@@ -7,20 +7,54 @@ use {
         EventStream,
         Recipe,
     }, n64flashcart, std::{
-        any::TypeId,
-        hash::Hash as _,
-        pin::Pin, sync::Arc,
-    }
+        any::TypeId, hash::Hash as _, pin::Pin, sync::Arc
+    }, tokio::time::sleep,
+    std::time::Duration,
 };
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum Error {
-    #[error("N64 reported as world 0")]
-    NotFound,
+    #[error("Flashcart disconnected")]
+    #[expect(dead_code)]
+    Disconnected,
 }
 
 pub(crate) struct Subscription {
 //    pub(crate) log: bool,
+}
+
+#[derive(Debug, Clone)]
+pub enum FlashcartState {
+    DISCONNECTED,
+    SEARCHING,
+    OPENING(String),
+    CONNECTED(String)
+}
+
+const FIVE_SECONDS : Duration = Duration::new(5, 0);
+
+async fn read() -> Option<FlashcartState> {
+    //self.game_state = GameState::Unknown;
+    match n64flashcart::read() {
+        Ok((header, data)) => {
+            if header.datatype == n64flashcart::USBDataType::HANDSHAKE || header.datatype == n64flashcart::USBDataType::HEARTBEAT {
+                println!("Handshake request detected");
+            } else if header.datatype == n64flashcart::USBDataType::EMPTY {
+                println!("No data to read while waiting for handshake");
+                sleep(FIVE_SECONDS).await;
+            } else {
+                println!("Invalid handshake, {}, {}", header.datatype.value(), data.iter().map(|b| format!("{:02x}", b)).collect::<Vec<String>>().join(" "));
+                //sleep(FIVE_SECONDS).await;
+            }
+        }
+        Err(e) => {
+            println!("Read error while waiting for handshake, {}", e.value());
+            //sleep(FIVE_SECONDS).await;
+            return Some(FlashcartState::DISCONNECTED);
+        }
+    }
+
+    return None;
 }
 
 impl Recipe for Subscription {
@@ -31,22 +65,43 @@ impl Recipe for Subscription {
     }
 
     fn stream(self: Box<Self>, _: EventStream) -> Pin<Box<dyn Stream<Item = Message> + Send>> {
-        println!("Flashcart stream");
+        stream::try_unfold(FlashcartState::SEARCHING, |state| async move {
+            let new_state = match &state {
+                FlashcartState::DISCONNECTED => {
+                    let _ = sleep(FIVE_SECONDS).await;
+                    Some(FlashcartState::SEARCHING)
+                },
+                FlashcartState::SEARCHING => {
+                    let status = n64flashcart::find();
+                    if status == n64flashcart::DeviceError::CARTFINDFAIL {
+                        n64flashcart::initialize();
+                        Some(FlashcartState::DISCONNECTED)
+                    } else if status != n64flashcart::DeviceError::OK {
+                        Some(FlashcartState::DISCONNECTED)
+                    } else {
+                        let cart_name = n64flashcart::cart_type_to_str(n64flashcart::get_cart());
+                        Some(FlashcartState::OPENING(cart_name.to_string()))
+                    }
+                },
+                FlashcartState::OPENING(name) => {
+                    let status = n64flashcart::open();
+                    if status != n64flashcart::DeviceError::OK {
+                        println!("Failed to open USB connection to flashcart, retrying, error code {}", status.value());
+                        Some(FlashcartState::DISCONNECTED)
+                    } else {
+                        println!("Flashcart USB connection opened");
+                        Some(FlashcartState::CONNECTED(name.clone()))
+                    }    
+                },
+                FlashcartState::CONNECTED(_name) => {
+                    read().await
+                }
+            };
 
-        stream::try_unfold(0, |_state| async move {
-            let status = n64flashcart::find();
-            if status == n64flashcart::DeviceError::CARTFINDFAIL {
-                println!("Flashcart disconnected, resetting");
-                n64flashcart::initialize();
-                return Err(Error::NotFound)
-            } else if status != n64flashcart::DeviceError::OK {
-                // Flashcart not found, wait and retry
-                // sleep(Duration(1));
-                println!("Flashcart not found");
-            } else {
-                println!("Flashcart found, {}", n64flashcart::cart_type_to_str(n64flashcart::get_cart()));
+            match new_state {
+                Some(value) => Ok(Some((Message::FlashcartStateChanged(value.clone()), value.clone()))),
+                None => Ok(Some((Message::Nop, state.clone())))
             }
-            return Ok(None)
         }).map(|res| res.unwrap_or_else(|e: Error | Message::FrontendSubscriptionError(Arc::new(e.into())))).boxed()
     }
 }

--- a/crate/multiworld-gui/src/flashcart.rs
+++ b/crate/multiworld-gui/src/flashcart.rs
@@ -24,27 +24,81 @@ pub(crate) struct Subscription {
 }
 
 #[derive(Debug, Clone)]
+pub(crate) enum CommState {
+    WaitForGame,
+    Handshake,
+    Idle
+}
+
+#[derive(Debug, Clone)]
 pub enum FlashcartState {
     DISCONNECTED,
     SEARCHING,
     OPENING(String),
-    CONNECTED(String)
+    CONNECTED(String, CommState)
 }
+
 
 const FIVE_SECONDS : Duration = Duration::new(5, 0);
 
-async fn read() -> Option<FlashcartState> {
-    //self.game_state = GameState::Unknown;
+fn send_hanshake() {
+    let msg = "cmdt".as_bytes().to_vec();
+    let header = n64flashcart::Header { datatype: n64flashcart::USBDataType::TEXT, length: msg.len() };
+
+    let _ = n64flashcart::write(header, msg);                        
+}
+
+fn process_message(comm_state: &CommState, header: n64flashcart::Header, data: Vec<u8>) -> CommState {
+    match comm_state {
+        CommState::WaitForGame => {
+            println!("Wait For Game");
+            if header.datatype == n64flashcart::USBDataType::HANDSHAKE {
+                send_hanshake();
+                CommState::Handshake
+            } else {
+                CommState::WaitForGame
+            }
+        }
+        CommState::Handshake => {
+            if data.len() < 16 {
+                println!("Invalid handshake reply, restarting handshake");
+                CommState::WaitForGame
+            } else if data[0] != b'O' || data[1] != b'o' || data[2] != b'T' || data[3] != b'R' {
+                println!("Invalid handshake reply, restarting handshake");
+                CommState::WaitForGame
+            } else {
+                let protocol_version = data[4];
+                let mut msg = "MW".as_bytes().to_vec();
+                msg.push(protocol_version);
+                msg.push(0); // MW_SEND_OWN_ITEMS
+                msg.push(0); // MW_PROGRESSIVE_ITEMS_ENABLE
+                let header = n64flashcart::Header { datatype: n64flashcart::USBDataType::RAWBINARY, length: msg.len() };
+                println!("Handshake reply received. Repeating protocol version to finalize handshake");
+                let status = n64flashcart::write(header, msg);
+                if status == n64flashcart::DeviceError::OK {
+                    println!("Protocol version sent");
+                    CommState::Idle
+                } else {
+                    println!("Failed to send protocol version, restarting handshake");
+                    CommState::WaitForGame
+                }
+            }
+        },
+        CommState::Idle => { CommState::Idle }
+    }
+}
+
+async fn read(name: &String, comm_state: &CommState) -> Option<FlashcartState> {
+    //self.comm_state = CommState::Unknown;
     match n64flashcart::read() {
         Ok((header, data)) => {
-            if header.datatype == n64flashcart::USBDataType::HANDSHAKE || header.datatype == n64flashcart::USBDataType::HEARTBEAT {
-                println!("Handshake request detected");
-            } else if header.datatype == n64flashcart::USBDataType::EMPTY {
-                println!("No data to read while waiting for handshake");
-                sleep(FIVE_SECONDS).await;
-            } else {
-                println!("Invalid handshake, {}, {}", header.datatype.value(), data.iter().map(|b| format!("{:02x}", b)).collect::<Vec<String>>().join(" "));
-                //sleep(FIVE_SECONDS).await;
+            if header.datatype == n64flashcart::USBDataType::EMPTY {
+                // Do nothing, no data
+            }
+            else {
+                println!("Datatype: {:?}, Length: {}, data: {:?}", header.datatype, header.length, data);
+                let new_comm_state = process_message(comm_state, header, data);
+                return Some(FlashcartState::CONNECTED(name.to_owned(), new_comm_state));
             }
         }
         Err(e) => {
@@ -90,11 +144,11 @@ impl Recipe for Subscription {
                         Some(FlashcartState::DISCONNECTED)
                     } else {
                         println!("Flashcart USB connection opened");
-                        Some(FlashcartState::CONNECTED(name.clone()))
+                        Some(FlashcartState::CONNECTED(name.to_owned(), CommState::WaitForGame))
                     }    
                 },
-                FlashcartState::CONNECTED(_name) => {
-                    read().await
+                FlashcartState::CONNECTED(name, comm_state) => {
+                    read(name, comm_state).await
                 }
             };
 

--- a/crate/multiworld-gui/src/flashcart.rs
+++ b/crate/multiworld-gui/src/flashcart.rs
@@ -1,37 +1,71 @@
 use {
-    crate::{FrontendWriter, Message}, arrayref::array_ref, enum_iterator::all, futures::{TryStreamExt as _, stream::{
+    crate::{FrontendWriter, Message}, arrayref::{array_mut_ref, array_ref}, enum_iterator::all, futures::{TryStreamExt as _, stream::{
             self,
             Stream,
             StreamExt as _,
     }}, iced::advanced::subscription::{
         EventStream,
         Recipe,
-    }, multiworld::{Filename, frontend::ClientMessage}, n64flashcart, ootr_utils::spoiler::HashIcon, std::{
-        any::TypeId, hash::Hash as _, num::NonZeroU8, pin::Pin, sync::Arc, time::Duration
+    }, multiworld::{Filename, frontend::{ClientMessage, ServerMessage}}, n64flashcart, ootr_utils::spoiler::HashIcon, std::{
+        any::TypeId, collections::{HashMap, VecDeque}, hash::Hash as _, num::NonZeroU8, pin::Pin, sync::Arc, time::Duration
     }, tokio::{select, sync::{Mutex, mpsc}, time::{sleep, timeout}}
 };
+
+const DEBUG_LOGGING: bool = true;
+
+macro_rules! dbg_println {
+    ($($arg:tt)*) => {
+        if DEBUG_LOGGING {
+            println!($($arg)*);
+        }
+    };
+}
 
 const PROTOCOL_VERSION: u8 = 1;
 const MW_SEND_OWN_ITEMS: u8 = 1;
 const MW_PROGRESSIVE_ITEMS_ENABLE: u8 = 1;
+
+const CMD_PLAYER_DATA: u8 = 1;
+const CMD_GET_ITEM: u8 = 2;
+const N64_ITEM_SEND: u8 = 3;
+const N64_ITEM_RECEIVED: u8 = 4;
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum Error {
     #[error("Flashcart disconnected")]
     #[expect(dead_code)]
     Disconnected,
+    #[error("received item for world 0")]
+    PlayerId,
 }
 
 pub(crate) struct Subscription {
 //    pub(crate) log: bool,
 }
- 
+
+#[derive(Debug, Clone)]
+pub(crate) enum InGameState {
+    Unknown,
+    FileSelect,
+    InGame,
+    Receiving
+}
+
+#[derive(Debug)]
+pub(crate) struct InGameStruct {
+    rx: mpsc::Receiver<ServerMessage>,
+    item_queue: VecDeque<u16>,
+    ingame_state: InGameState,
+    filename: Option<Filename>,
+    player_data: HashMap<NonZeroU8, (Filename, u32)>,
+} 
+
 #[derive(Debug, Clone)]
 pub(crate) enum CommState {
     SendHandshake,
     WaitForGame,
     Handshake,
-    Ready(Arc<Mutex<mpsc::Receiver<multiworld::frontend::ServerMessage>>>)
+    Ready(Arc<Mutex<InGameStruct>>)
 }
 
 #[derive(Debug, Clone)]
@@ -41,7 +75,6 @@ pub enum FlashcartState {
     OPENING(String),
     CONNECTED(String, CommState)
 }
-
 
 const FIVE_SECONDS : Duration = Duration::new(5, 0);
 
@@ -79,6 +112,116 @@ async fn n64_recv() -> Result<(n64flashcart::Header, Vec<u8>), n64flashcart::Dev
     }
 }
 
+fn n64_send(datatype: n64flashcart::USBDataType, msg: Vec<u8>) -> Result<(), n64flashcart::DeviceError> {
+    let header = n64flashcart::Header { datatype: datatype, length: msg.len() };
+    let status = n64flashcart::write(header, msg);
+    match status {
+        n64flashcart::DeviceError::OK => Ok(()),
+        _ => Err(status)
+    }
+}
+
+fn send_player_data(world: NonZeroU8, name: Filename, progressive_items: u32) -> Result<(), n64flashcart::DeviceError> {
+    let mut buf = [0; 16];
+
+    buf[0] = CMD_PLAYER_DATA;
+    buf[1] = world.get();
+    *array_mut_ref![buf, 2, 8] = name.0;
+    *array_mut_ref![buf, 10, 4] = progressive_items.to_be_bytes();
+
+    n64_send(n64flashcart::USBDataType::RAWBINARY, Vec::from(buf))
+}
+
+fn send_item(item: u16) -> Result<(), n64flashcart::DeviceError> {
+    let mut msg: Vec<u8> = Vec::new();
+
+    msg.push(CMD_GET_ITEM);
+
+    let [b1, b2] = item.to_be_bytes();
+    msg.push(b1);
+    msg.push(b2);
+
+    n64_send(n64flashcart::USBDataType::RAWBINARY, msg)
+}
+
+fn process_n64_packet(header: n64flashcart::Header, data: Vec<u8>, struc: &mut InGameStruct) -> (Option<InGameState>, Option<Vec<Message>>)
+{
+    match header.datatype {
+        n64flashcart::USBDataType::INGAME_STATE => dbg_println!("Datatype: {:?}, Length: {}", header.datatype, header.length),
+        _ => dbg_println!("Datatype: {:?}, Length: {}, data: {:?}", header.datatype, header.length, data)
+    };
+
+    match header.datatype {
+        n64flashcart::USBDataType::SAVE_FILENAME => {
+            if data.len() >= 9 {
+                let data_slice = data.into_boxed_slice();
+                let fname = *array_ref![data_slice, 1, 8];
+
+                match fname {
+                    [0, 0, 0, 0, 0, 0, 0, 0] => {
+                        (Some(InGameState::FileSelect), None)
+                    },
+                    _ => {
+                        let filename = Filename(fname);
+                        if let None = struc.filename {
+                            struc.filename = Some(filename);
+                        }
+
+                        (Some(InGameState::InGame), Some(vec![Message::Plugin(Box::new(ClientMessage::PlayerName(filename)))]))
+                    }
+
+                }
+            }
+            else {
+                (None, None)
+            }
+        },
+
+        n64flashcart::USBDataType::INGAME_STATE => {
+            if let Ok(savedata) = TryInto::<[u8 ; 5200]>::try_into(data) {
+                let mut messages = Vec::new();
+                
+                if let None = struc.filename {
+                    let filename = Filename(*array_ref![savedata, 0x024, 8]);
+                    struc.filename = Some(filename);
+                    messages.push(Message::Plugin(Box::new(ClientMessage::PlayerName(filename))));
+                }
+
+                messages.push(Message::Plugin(Box::new(ClientMessage::SaveData(savedata))));
+
+                (Some(InGameState::InGame), Some(messages))
+            } else {
+                (None, None)
+            }            
+        },
+
+        n64flashcart::USBDataType::RAWBINARY =>  {
+            match data[0] {
+                N64_ITEM_SEND => {  // Item sent
+                    let data_slice = data.into_boxed_slice();
+
+                    let kind = u16::from_be_bytes(*array_ref![data_slice, 9, 2]);
+                    let target_world = NonZeroU8::new(data_slice[11]).ok_or(Error::PlayerId).unwrap();
+
+                    dbg_println!("Got item {} for world {}", kind, target_world);
+
+                    let message = Message::Plugin(Box::new(ClientMessage::SendItem {
+                        key: u64::from_be_bytes(*array_ref![data_slice, 1, 8]),
+                        kind: kind,
+                        target_world: target_world,
+                    }));
+
+                    (None, Some(vec![message]))
+                }
+                N64_ITEM_RECEIVED => (Some(InGameState::InGame), None), // Item receive confirmation
+                _ => (None, None)
+            }
+        },
+
+        _ => (None, None)
+    }
+}
+
 fn process_message(comm_state: &CommState, header: n64flashcart::Header, data: Vec<u8>) -> (Option<CommState>, Vec<Message>) {
     let mut messages = Vec::new();
     let next_comm_state = match comm_state {
@@ -98,11 +241,11 @@ fn process_message(comm_state: &CommState, header: n64flashcart::Header, data: V
                 Ok(value) => {
                     match value {
                         [b'O', b'o', b'T', b'R', PROTOCOL_VERSION, major, minor, patch, branch, supplementary, player_id, hash1, hash2, hash3, hash4, hash5] => {
-                            println!("Handshake reply received. Repeating protocol version to finalize handshake");
+                            dbg_println!("Handshake reply received. Repeating protocol version to finalize handshake");
                             let res = send_handshake_response();
                             match res {
                                 Ok(_) => {
-                                    println!("Protocol version sent");
+                                    dbg_println!("Protocol version sent");
 
                                     let _version = ootr_utils::Version::from_bytes([major, minor, patch, branch, supplementary]).unwrap();
                                     let player_id = NonZeroU8::new(player_id).unwrap();
@@ -120,22 +263,30 @@ fn process_message(comm_state: &CommState, header: n64flashcart::Header, data: V
                                     messages.push(Message::Plugin(Box::new(ClientMessage::PlayerId(player_id))));
                                     messages.push(Message::Plugin(Box::new(ClientMessage::FileHash(Some(file_hash)))));
 
-                                    Some(CommState::Ready(Arc::new(Mutex::new(rx))))
+                                    let struc = InGameStruct {
+                                        rx: rx,
+                                        item_queue: VecDeque::new(),
+                                        ingame_state: InGameState::Unknown,
+                                        filename: None,
+                                        player_data: HashMap::default()
+                                    };
+
+                                    Some(CommState::Ready(Arc::new(Mutex::new(struc))))
                                 },
                                 Err(_) => {
-                                    println!("Failed to send protocol version, restarting handshake");
+                                    dbg_println!("Failed to send protocol version, restarting handshake");
                                     Some(CommState::WaitForGame)
                                 }
                             }
                         },
                         _ => {
-                            println!("Invalid handshake reply, restarting handshake");
+                            dbg_println!("Invalid handshake reply, restarting handshake");
                             Some(CommState::WaitForGame)
                         }
                     } 
                 },
                 Err(_) => {
-                    println!("Invalid handshake reply, restarting handshake");
+                    dbg_println!("Invalid handshake reply, restarting handshake");
                     Some(CommState::WaitForGame)
                 }
             }
@@ -152,47 +303,70 @@ async fn read(name: &String, comm_state: &CommState) -> (Option<FlashcartState>,
             send_handshake();
             Some(FlashcartState::CONNECTED(name.to_owned(), CommState::Handshake))
         },
-        CommState::Ready(_rx) => {
-            let mut rx = _rx.lock().await;
-            let mut messages: Vec<Message> = Vec::new();
+        CommState::Ready(_struc) => {
+            let mut struc = _struc.lock().await;
+            let mut messages = Vec::new();
+
+            if !struc.item_queue.is_empty() {
+                if let InGameState::InGame = struc.ingame_state {
+                    let item = struc.item_queue.pop_front().unwrap();
+                    let _ = send_item(item);
+
+                    struc.ingame_state = InGameState::Receiving;
+                }
+            }
 
             select! {
-                res = timeout(Duration::from_secs(5), n64_recv()) => {
-                    match res {
-                        Ok(res) => {
-                            match res {
+                n64_or_timeout = timeout(Duration::from_secs(5), n64_recv()) => {
+                    match n64_or_timeout {
+                        Ok(n64_result) => {
+                            match n64_result {
                                 Ok((header, data)) => {
-                                    println!("Datatype: {:?}, Length: {}", header.datatype, header.length);
-                                    if header.datatype == n64flashcart::USBDataType::SAVE_FILENAME {
-                                        if data.len() >= 9 {
-                                            messages.push(Message::Plugin(Box::new(ClientMessage::PlayerName(Filename(*array_ref![data, 1, 8])))));
-                                        }
+                                    let (state_, messages_) = process_n64_packet(header, data, &mut struc);
+                                    if let Some(value) = state_ {
+                                        struc.ingame_state = value;
                                     }
-                                    
-                                    if header.datatype == n64flashcart::USBDataType::INGAME_STATE {
-                                        if let Ok(savedata) = TryInto::<[u8 ; 5200]>::try_into(data) {
-                                            messages.push(Message::Plugin(Box::new(ClientMessage::SaveData(savedata))));
-                                        }
+                                    if let Some(msg) = messages_ {
+                                        messages.extend(msg);
                                     }
                                 },
                                 Err(e) => {
-                                    println!("Error receiving from n64, {:?}", e);
+                                    dbg_println!("Error receiving from n64, {:?}", e);
                                     return (Some(FlashcartState::DISCONNECTED), vec![]);
                                 }
-                            };
+                            }
                         },
                         Err(_) => {
-                            println!("No message from N64 in 5 seconds");
+                            dbg_println!("No message from N64 in 5 seconds");
                             return (Some(FlashcartState::DISCONNECTED), vec![]);
                         }
                     };
                 },
-                Some(msg) = rx.recv() => {
-                    println!("Received message from MH, {:?}", msg);
+                Some(msg) = struc.rx.recv() => {
+                    dbg_println!("Received message from MH, {:?}", msg);
+                    match msg {
+                        ServerMessage::ItemQueue(items) => {
+                            struc.item_queue.extend(items);
+                        },
+                        ServerMessage::GetItem(item) => {
+                            struc.item_queue.push_back(item);
+                        },
+                        ServerMessage::PlayerName(world, new_name) => {
+                            let (name, progressive_items) = struc.player_data.entry(world).or_default();
+                            *name = new_name;
+                            let _ = send_player_data(world, *name, *progressive_items);
+                        },
+                        ServerMessage::ProgressiveItems(world, new_progressive_items) => {
+                            let (name, progressive_items) = struc.player_data.entry(world).or_default();
+                            *progressive_items = new_progressive_items;
+                            let _ = send_player_data(world, *name, *progressive_items);
+                        },
+                    }
                     
                 }
             };
             
+            dbg_println!("InGameState: {:?}", struc.ingame_state);
             return (None, messages);
         },
         _ => {
@@ -203,20 +377,13 @@ async fn read(name: &String, comm_state: &CommState) -> (Option<FlashcartState>,
                         None
                     }
                     else {
-                        if header.datatype == n64flashcart::USBDataType::INGAME_STATE {
-                            //println!("Datatype: {:?}, Length: {}", header.datatype, header.length); 
-                        }
-                        else
-                        {
-                            println!("Datatype: {:?}, Length: {}, data: {:?}", header.datatype, header.length, data);
-                        }
                         let (new_comm_state, messages) = process_message(comm_state, header, data);
                         let next_state = new_comm_state.map(|state| FlashcartState::CONNECTED(name.to_owned(), state));
                         return (next_state, messages);
                     }
                 }
                 Err(e) => {
-                    println!("Read error while waiting for handshake, {}", e.value());
+                    dbg_println!("Read error while waiting for handshake, {}", e.value());
                     //sleep(FIVE_SECONDS).await;
                     Some(FlashcartState::DISCONNECTED)
                 }
@@ -259,10 +426,10 @@ impl Recipe for Subscription {
                 FlashcartState::OPENING(name) => {
                     let status = n64flashcart::open();
                     if status != n64flashcart::DeviceError::OK {
-                        println!("Failed to open USB connection to flashcart, retrying, error code {}", status.value());
+                        dbg_println!("Failed to open USB connection to flashcart, retrying, error code {}", status.value());
                         Some(FlashcartState::DISCONNECTED)
                     } else {
-                        println!("Flashcart USB connection opened");
+                        dbg_println!("Flashcart USB connection opened");
                         Some(FlashcartState::CONNECTED(name.to_owned(), CommState::SendHandshake))
                     }    
                 },
@@ -278,6 +445,21 @@ impl Recipe for Subscription {
             }
 
             Ok::<_, Error>(Some((stream::iter(messages).map(Ok::<_, Error>), new_state.unwrap_or(state))))
-        }).try_flatten().map(|res| res.unwrap_or_else(|e| Message::FrontendSubscriptionError(Arc::new(e.into())))).boxed()
+        }).try_flatten().map(|res| {
+            let mut print_debug = true;
+
+            if let Ok(message) = &res {
+                if let Message::Plugin(plugin) = message {
+                    if let ClientMessage::SaveData(_) = plugin.as_ref() {
+                        print_debug = false;
+                    }
+                }
+            }
+
+            if print_debug {
+                dbg_println!("{:?}", res);
+            }
+            res.unwrap_or_else(|e| Message::FrontendSubscriptionError(Arc::new(e.into())))
+        }).boxed()
     }
 }

--- a/crate/multiworld-gui/src/flashcart.rs
+++ b/crate/multiworld-gui/src/flashcart.rs
@@ -1,16 +1,19 @@
 use {
-    crate::Message, futures::stream::{
+    crate::{FrontendWriter, Message}, arrayref::array_ref, enum_iterator::all, futures::{TryStreamExt as _, stream::{
             self,
             Stream,
             StreamExt as _,
-    }, iced::advanced::subscription::{
+    }}, iced::advanced::subscription::{
         EventStream,
         Recipe,
-    }, n64flashcart, std::{
-        any::TypeId, hash::Hash as _, pin::Pin, sync::Arc
-    }, tokio::time::sleep,
-    std::time::Duration,
+    }, multiworld::{Filename, frontend::ClientMessage}, n64flashcart, ootr_utils::spoiler::HashIcon, std::{
+        any::TypeId, hash::Hash as _, num::NonZeroU8, pin::Pin, sync::Arc, time::Duration
+    }, tokio::{select, sync::{Mutex, mpsc}, time::{sleep, timeout}}
 };
+
+const PROTOCOL_VERSION: u8 = 1;
+const MW_SEND_OWN_ITEMS: u8 = 1;
+const MW_PROGRESSIVE_ITEMS_ENABLE: u8 = 1;
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum Error {
@@ -22,12 +25,13 @@ pub(crate) enum Error {
 pub(crate) struct Subscription {
 //    pub(crate) log: bool,
 }
-
+ 
 #[derive(Debug, Clone)]
 pub(crate) enum CommState {
+    SendHandshake,
     WaitForGame,
     Handshake,
-    Idle
+    Ready(Arc<Mutex<mpsc::Receiver<multiworld::frontend::ServerMessage>>>)
 }
 
 #[derive(Debug, Clone)]
@@ -41,74 +45,186 @@ pub enum FlashcartState {
 
 const FIVE_SECONDS : Duration = Duration::new(5, 0);
 
-fn send_hanshake() {
+fn send_handshake() {
     let msg = "cmdt".as_bytes().to_vec();
     let header = n64flashcart::Header { datatype: n64flashcart::USBDataType::TEXT, length: msg.len() };
 
-    let _ = n64flashcart::write(header, msg);                        
+    let _ = n64flashcart::write(header, msg);
 }
 
-fn process_message(comm_state: &CommState, header: n64flashcart::Header, data: Vec<u8>) -> CommState {
-    match comm_state {
+fn send_handshake_response() -> Result<(), n64flashcart::DeviceError>  {
+    let mut msg = "MW".as_bytes().to_vec();
+    msg.push(PROTOCOL_VERSION);
+    msg.push(MW_SEND_OWN_ITEMS); // MW_SEND_OWN_ITEMS
+    msg.push(MW_PROGRESSIVE_ITEMS_ENABLE); // MW_PROGRESSIVE_ITEMS_ENABLE
+    let header = n64flashcart::Header { datatype: n64flashcart::USBDataType::RAWBINARY, length: msg.len() };
+    let status = n64flashcart::write(header, msg);
+    
+    match status {
+        n64flashcart::DeviceError::OK => Ok(()),
+        _ => Err(status)
+    }
+}
+
+async fn n64_recv() -> Result<(n64flashcart::Header, Vec<u8>), n64flashcart::DeviceError> {
+    loop {
+        match n64flashcart::read() {
+            Ok((header, data)) => {
+                if header.datatype != n64flashcart::USBDataType::EMPTY {
+                    return Ok((header, data));
+                }
+            }
+            Err(e) => return Err(e),
+        };
+    }
+}
+
+fn process_message(comm_state: &CommState, header: n64flashcart::Header, data: Vec<u8>) -> (Option<CommState>, Vec<Message>) {
+    let mut messages = Vec::new();
+    let next_comm_state = match comm_state {
+        CommState::SendHandshake => {
+            send_handshake();
+            Some(CommState::Handshake)
+        }
         CommState::WaitForGame => {
-            println!("Wait For Game");
             if header.datatype == n64flashcart::USBDataType::HANDSHAKE {
-                send_hanshake();
-                CommState::Handshake
+                Some(CommState::SendHandshake)
             } else {
-                CommState::WaitForGame
+                None
             }
         }
         CommState::Handshake => {
-            if data.len() < 16 {
-                println!("Invalid handshake reply, restarting handshake");
-                CommState::WaitForGame
-            } else if data[0] != b'O' || data[1] != b'o' || data[2] != b'T' || data[3] != b'R' {
-                println!("Invalid handshake reply, restarting handshake");
-                CommState::WaitForGame
-            } else {
-                let protocol_version = data[4];
-                let mut msg = "MW".as_bytes().to_vec();
-                msg.push(protocol_version);
-                msg.push(0); // MW_SEND_OWN_ITEMS
-                msg.push(0); // MW_PROGRESSIVE_ITEMS_ENABLE
-                let header = n64flashcart::Header { datatype: n64flashcart::USBDataType::RAWBINARY, length: msg.len() };
-                println!("Handshake reply received. Repeating protocol version to finalize handshake");
-                let status = n64flashcart::write(header, msg);
-                if status == n64flashcart::DeviceError::OK {
-                    println!("Protocol version sent");
-                    CommState::Idle
-                } else {
-                    println!("Failed to send protocol version, restarting handshake");
-                    CommState::WaitForGame
+            match TryInto::<[u8 ; 16]>::try_into(data) {
+                Ok(value) => {
+                    match value {
+                        [b'O', b'o', b'T', b'R', PROTOCOL_VERSION, major, minor, patch, branch, supplementary, player_id, hash1, hash2, hash3, hash4, hash5] => {
+                            println!("Handshake reply received. Repeating protocol version to finalize handshake");
+                            let res = send_handshake_response();
+                            match res {
+                                Ok(_) => {
+                                    println!("Protocol version sent");
+
+                                    let _version = ootr_utils::Version::from_bytes([major, minor, patch, branch, supplementary]).unwrap();
+                                    let player_id = NonZeroU8::new(player_id).unwrap();
+                                    let file_hash: [HashIcon; 5] = [
+                                        all().nth(hash1.into()).unwrap(),
+                                        all().nth(hash2.into()).unwrap(),
+                                        all().nth(hash3.into()).unwrap(),
+                                        all().nth(hash4.into()).unwrap(),
+                                        all().nth(hash5.into()).unwrap(),
+                                    ];
+                                    
+                                    let (tx, rx) = mpsc::channel(1_024);
+
+                                    messages.push(Message::FrontendConnected(FrontendWriter::Mpsc(tx)));
+                                    messages.push(Message::Plugin(Box::new(ClientMessage::PlayerId(player_id))));
+                                    messages.push(Message::Plugin(Box::new(ClientMessage::FileHash(Some(file_hash)))));
+
+                                    Some(CommState::Ready(Arc::new(Mutex::new(rx))))
+                                },
+                                Err(_) => {
+                                    println!("Failed to send protocol version, restarting handshake");
+                                    Some(CommState::WaitForGame)
+                                }
+                            }
+                        },
+                        _ => {
+                            println!("Invalid handshake reply, restarting handshake");
+                            Some(CommState::WaitForGame)
+                        }
+                    } 
+                },
+                Err(_) => {
+                    println!("Invalid handshake reply, restarting handshake");
+                    Some(CommState::WaitForGame)
                 }
             }
         },
-        CommState::Idle => { CommState::Idle }
-    }
+        CommState::Ready(_) => None,
+    };
+
+    (next_comm_state, messages)
 }
 
-async fn read(name: &String, comm_state: &CommState) -> Option<FlashcartState> {
-    //self.comm_state = CommState::Unknown;
-    match n64flashcart::read() {
-        Ok((header, data)) => {
-            if header.datatype == n64flashcart::USBDataType::EMPTY {
-                // Do nothing, no data
-            }
-            else {
-                println!("Datatype: {:?}, Length: {}, data: {:?}", header.datatype, header.length, data);
-                let new_comm_state = process_message(comm_state, header, data);
-                return Some(FlashcartState::CONNECTED(name.to_owned(), new_comm_state));
-            }
-        }
-        Err(e) => {
-            println!("Read error while waiting for handshake, {}", e.value());
-            //sleep(FIVE_SECONDS).await;
-            return Some(FlashcartState::DISCONNECTED);
-        }
-    }
+async fn read(name: &String, comm_state: &CommState) -> (Option<FlashcartState>, Vec<Message>) {
+    let next_state = match comm_state {
+        CommState::SendHandshake => {
+            send_handshake();
+            Some(FlashcartState::CONNECTED(name.to_owned(), CommState::Handshake))
+        },
+        CommState::Ready(_rx) => {
+            let mut rx = _rx.lock().await;
+            let mut messages: Vec<Message> = Vec::new();
 
-    return None;
+            select! {
+                res = timeout(Duration::from_secs(5), n64_recv()) => {
+                    match res {
+                        Ok(res) => {
+                            match res {
+                                Ok((header, data)) => {
+                                    println!("Datatype: {:?}, Length: {}", header.datatype, header.length);
+                                    if header.datatype == n64flashcart::USBDataType::SAVE_FILENAME {
+                                        if data.len() >= 9 {
+                                            messages.push(Message::Plugin(Box::new(ClientMessage::PlayerName(Filename(*array_ref![data, 1, 8])))));
+                                        }
+                                    }
+                                    
+                                    if header.datatype == n64flashcart::USBDataType::INGAME_STATE {
+                                        if let Ok(savedata) = TryInto::<[u8 ; 5200]>::try_into(data) {
+                                            messages.push(Message::Plugin(Box::new(ClientMessage::SaveData(savedata))));
+                                        }
+                                    }
+                                },
+                                Err(e) => {
+                                    println!("Error receiving from n64, {:?}", e);
+                                    return (Some(FlashcartState::DISCONNECTED), vec![]);
+                                }
+                            };
+                        },
+                        Err(_) => {
+                            println!("No message from N64 in 5 seconds");
+                            return (Some(FlashcartState::DISCONNECTED), vec![]);
+                        }
+                    };
+                },
+                Some(msg) = rx.recv() => {
+                    println!("Received message from MH, {:?}", msg);
+                    
+                }
+            };
+            
+            return (None, messages);
+        },
+        _ => {
+            match n64flashcart::read() {
+                Ok((header, data)) => {
+                    if header.datatype == n64flashcart::USBDataType::EMPTY {
+                        // Do nothing, no data
+                        None
+                    }
+                    else {
+                        if header.datatype == n64flashcart::USBDataType::INGAME_STATE {
+                            //println!("Datatype: {:?}, Length: {}", header.datatype, header.length); 
+                        }
+                        else
+                        {
+                            println!("Datatype: {:?}, Length: {}, data: {:?}", header.datatype, header.length, data);
+                        }
+                        let (new_comm_state, messages) = process_message(comm_state, header, data);
+                        let next_state = new_comm_state.map(|state| FlashcartState::CONNECTED(name.to_owned(), state));
+                        return (next_state, messages);
+                    }
+                }
+                Err(e) => {
+                    println!("Read error while waiting for handshake, {}", e.value());
+                    //sleep(FIVE_SECONDS).await;
+                    Some(FlashcartState::DISCONNECTED)
+                }
+            }
+        }
+    };
+
+    (next_state, vec![])
 }
 
 impl Recipe for Subscription {
@@ -120,6 +236,9 @@ impl Recipe for Subscription {
 
     fn stream(self: Box<Self>, _: EventStream) -> Pin<Box<dyn Stream<Item = Message> + Send>> {
         stream::try_unfold(FlashcartState::SEARCHING, |state| async move {
+            let _ = sleep(Duration::from_millis(100)).await;
+            let mut messages: Vec<Message> = Vec::new();
+
             let new_state = match &state {
                 FlashcartState::DISCONNECTED => {
                     let _ = sleep(FIVE_SECONDS).await;
@@ -144,18 +263,21 @@ impl Recipe for Subscription {
                         Some(FlashcartState::DISCONNECTED)
                     } else {
                         println!("Flashcart USB connection opened");
-                        Some(FlashcartState::CONNECTED(name.to_owned(), CommState::WaitForGame))
+                        Some(FlashcartState::CONNECTED(name.to_owned(), CommState::SendHandshake))
                     }    
                 },
                 FlashcartState::CONNECTED(name, comm_state) => {
-                    read(name, comm_state).await
+                    let (next_state, m) = read(name, comm_state).await;
+                    messages.extend(m);
+                    next_state
                 }
             };
 
-            match new_state {
-                Some(value) => Ok(Some((Message::FlashcartStateChanged(value.clone()), value.clone()))),
-                None => Ok(Some((Message::Nop, state.clone())))
+            if let Some(value) = &new_state {
+                messages.push(Message::FlashcartStateChanged(value.clone()));
             }
-        }).map(|res| res.unwrap_or_else(|e: Error | Message::FrontendSubscriptionError(Arc::new(e.into())))).boxed()
+
+            Ok::<_, Error>(Some((stream::iter(messages).map(Ok::<_, Error>), new_state.unwrap_or(state))))
+        }).try_flatten().map(|res| res.unwrap_or_else(|e| Message::FrontendSubscriptionError(Arc::new(e.into())))).boxed()
     }
 }

--- a/crate/multiworld-gui/src/flashcart.rs
+++ b/crate/multiworld-gui/src/flashcart.rs
@@ -13,10 +13,10 @@ use {
             Stream,
             StreamExt as _,
         },
-    }, iced::{advanced::subscription::{
+    }, iced::advanced::subscription::{
         EventStream,
         Recipe,
-    }}, log_lock::lock, multiworld::{
+    }, log_lock::lock, multiworld::{
         Filename, HintArea, OptHintArea, frontend::{
             ClientMessage,
             ServerMessage
@@ -79,6 +79,8 @@ const MW_PROGRESSIVE_ITEMS_ENABLE: u8 = 1;
 pub(crate) enum ConnectError {
     #[error("unknown branch identifier: 0x{0:02x}")]
     Branch(u8),
+    #[error("mismatched communications protocol: {0}")]
+    Protocol(u8),
     #[error("failed to decode hash icon")]
     HashIcon,
     #[cfg(unix)]
@@ -146,16 +148,24 @@ pub(crate) enum CommState {
     SendHandshake,
     WaitForGame,
     Handshake,
-    Ready(Arc<Mutex<InGameStruct>>)
+    Ready{ game_state: Arc<Mutex<InGameStruct>> }
 }
 
 #[derive(Debug, Clone)]
 pub enum FlashcartState {
     INITIALIZE,
-    DISCONNECTED(FlashcartCache),
-    SEARCHING(FlashcartCache),
-    OPENING(String, FlashcartCache),
-    CONNECTED(String, CommState, FlashcartCache, Arc<FlashcartGuard>)
+    DISCONNECTED{ data_cache: FlashcartCache },
+    SEARCHING{ data_cache: FlashcartCache },
+    OPENING{
+        cart_name: String,
+        data_cache: FlashcartCache,
+    },
+    CONNECTED{
+        cart_name: String,
+        connection_state: CommState,
+        data_cache: FlashcartCache,
+        disconnect_guard: Arc<FlashcartGuard>,
+    }
 }
 
 #[derive(Debug)]
@@ -222,8 +232,8 @@ async fn n64_send(datatype: USBDataType, msg: Vec<u8>) -> Result<(), DeviceError
     }
 }
 
-async fn send_handshake() {
-    let _ = n64_send(USBDataType::HANDSHAKE, "cmdt".as_bytes().to_vec()).await;
+async fn send_handshake() -> Result<(), DeviceError> {
+    n64_send(USBDataType::HANDSHAKE, "cmdt".as_bytes().to_vec()).await
 }
 
 async fn send_handshake_response() -> Result<(), DeviceError> {
@@ -235,16 +245,21 @@ async fn send_handshake_response() -> Result<(), DeviceError> {
     n64_send(USBDataType::HANDSHAKE, msg).await
 }
 
-async fn send_reset() {
-    let _ = n64_send(USBDataType::RESET, vec![0u8, 16]).await;
+// OK to ignore errors from signal-type messages as the
+// game will eventually reset state after no reply. The
+// client then resets itself if it hasn't already when
+// reading a new handshake message instead of a heartbeat,
+// or if it gets no messages from the console for a period of time.
+async fn send_reset() -> Result<(), DeviceError> {
+    n64_send(USBDataType::RESET, vec![0u8, 16]).await
 }
 
-async fn send_ack() {
-    let _ = n64_send(USBDataType::ACK_MESSAGE, vec![0u8, 16]).await;
+async fn send_ack() -> Result<(), DeviceError> {
+    n64_send(USBDataType::ACK_MESSAGE, vec![0u8, 16]).await
 }
 
-async fn send_err() {
-    let _ = n64_send(USBDataType::UNRECOVERABLE, vec![0u8, 16]).await;
+async fn send_err() -> Result<(), DeviceError> {
+    n64_send(USBDataType::UNRECOVERABLE, vec![0u8, 16]).await
 }
 
 async fn send_player_data(world: NonZeroU8, name: Filename, progressive_items: u32) -> (USBDataType, Vec<u8>) {
@@ -304,10 +319,10 @@ async fn process_n64_packet(header: n64flashcart::Header, data: Vec<u8>, struc: 
                 let filename = Filename(*array_ref![data_slice, 0, 8]);
                 struc.filename = Some(filename);
 
-                send_ack().await;
+                send_ack().await?;
                 Ok((Some(InGameState::FileSelect), Some(vec![Message::Plugin(Box::new(ClientMessage::PlayerName(filename)))])))
             } else {
-                send_err().await;
+                send_err().await?;
                 Ok((None, None))
             }
         },
@@ -333,10 +348,10 @@ async fn process_n64_packet(header: n64flashcart::Header, data: Vec<u8>, struc: 
                     get_item(&struc.item_queue, &internal_count, &mut struc.message_queue).await
                 };
 
-                send_ack().await;
+                send_ack().await?;
                 Ok((Some(InGameState::InGame { internal_count, item_pending }), Some(messages)))
             } else {
-                send_err().await;
+                send_err().await?;
                 Ok((Some(InGameState::NotKnown), None))
             }
         },
@@ -346,7 +361,7 @@ async fn process_n64_packet(header: n64flashcart::Header, data: Vec<u8>, struc: 
                 let data_slice = data.into_boxed_slice();
 
                 let kind = u16::from_be_bytes(*array_ref![data_slice, 8, 2]);
-                let target_world = NonZeroU8::new(data_slice[10]).ok_or(ConnectError::PlayerId).unwrap();
+                let target_world = NonZeroU8::new(data_slice[10]).ok_or(DeviceError::FILEREADFAIL)?;
 
                 dbg_println!("Got item {} for world {}", kind, target_world);
 
@@ -356,10 +371,10 @@ async fn process_n64_packet(header: n64flashcart::Header, data: Vec<u8>, struc: 
                     target_world: target_world,
                 }));
 
-                send_ack().await;
+                send_ack().await?;
                 Ok((None, Some(vec![message])))
             } else {
-                send_err().await;
+                send_err().await?;
                 Ok((None, None))
             }
         },
@@ -390,7 +405,7 @@ async fn process_n64_packet(header: n64flashcart::Header, data: Vec<u8>, struc: 
                 if !*item_pending {
                     Ok((Some(InGameState::Desynced), None))
                 } else {
-                    send_ack().await;
+                    send_ack().await?;
                     *internal_count += 1;
                     if !get_item(&struc.item_queue, internal_count, message_queue).await {
                         *item_pending = false;
@@ -447,21 +462,21 @@ async fn process_n64_packet(header: n64flashcart::Header, data: Vec<u8>, struc: 
                     spirit: if let (Some(world), Some(area)) = (NonZeroU8::new(spirit_world), OptHintArea::from_u8(spirit_area).and_then(|area| HintArea::try_from(area).ok())) { Some((world, area)) } else { None },
                 }))];
 
-                send_ack().await;
+                send_ack().await?;
                 Ok((None, Some(message)))
             } else {
-                send_err().await;
+                send_err().await?;
                 Ok((None, None))
             }
         },
 
         USBDataType::SEND_HINT => {
-            send_ack().await;
+            send_ack().await?;
             Ok((None, None))
         },
 
         USBDataType::SEND_ENTRANCE => {
-            send_ack().await;
+            send_ack().await?;
             Ok((None, None))
         },
 
@@ -485,7 +500,7 @@ async fn process_n64_packet(header: n64flashcart::Header, data: Vec<u8>, struc: 
                     // Handle raw byte message here
                     *pending_message = None;
                 }
-                send_ack().await;
+                send_ack().await?;
                 Ok((None, None))
             }
         }
@@ -506,6 +521,7 @@ async fn process_handshake(header: n64flashcart::Header, data: Vec<u8>) -> Resul
             match value {
                 [b'O', b'o', b'T', b'R', PROTOCOL_VERSION, major, minor, patch, branch, supplementary, player_id, hash1, hash2, hash3, hash4, hash5] => {
                     dbg_println!("Handshake reply received. Repeating protocol version to finalize handshake");
+                    
                     match send_handshake_response().await {
                         Ok(_) => {
                             dbg_println!("Protocol version sent");
@@ -527,6 +543,10 @@ async fn process_handshake(header: n64flashcart::Header, data: Vec<u8>) -> Resul
                             Err(ConnectError::FailedReply)
                         }
                     }
+                },
+                [b'O', b'o', b'T', b'R', other_protocol_version, _, _, _, _, _, _, _, _, _, _, _] => {
+                    dbg_println!("Mismatched communications protocol version, restarting handshake");
+                    Err(ConnectError::Protocol(other_protocol_version))
                 },
                 _ => {
                     dbg_println!("Invalid handshake reply, restarting handshake");
@@ -555,7 +575,7 @@ async fn read(comm_state: &CommState, cache: &FlashcartCache) -> Result<(Option<
                                     Some(CommState::SendHandshake)
                                 },
                                 _ => {
-                                    send_reset().await;
+                                    send_reset().await?;
                                     None
                                 }
                             }
@@ -573,7 +593,7 @@ async fn read(comm_state: &CommState, cache: &FlashcartCache) -> Result<(Option<
             }
         },
         CommState::SendHandshake => {
-            send_handshake().await;
+            send_handshake().await?;
             Some(CommState::Handshake)
         },
         CommState::Handshake => {
@@ -606,7 +626,7 @@ async fn read(comm_state: &CommState, cache: &FlashcartCache) -> Result<(Option<
                                     pending_message: None,
                                 };
 
-                                Some(CommState::Ready(Arc::new(Mutex::new(struc))))
+                                Some(CommState::Ready{game_state: Arc::new(Mutex::new(struc))})
                             } else if errors.is_empty() {
                                 None
                             } else {
@@ -626,8 +646,8 @@ async fn read(comm_state: &CommState, cache: &FlashcartCache) -> Result<(Option<
                 }
             }
         },
-        CommState::Ready(_struc) => {
-            let mut struc = _struc.lock().await;
+        CommState::Ready{game_state} => {
+            let mut struc = game_state.lock().await;
 
             dbg_println!("InGameState: {:?}", struc.ingame_state);
 
@@ -680,10 +700,10 @@ async fn read(comm_state: &CommState, cache: &FlashcartCache) -> Result<(Option<
                                         }
                                         Err(e) => {
                                             let mut errors = Vec::default();
-                                            if let DeviceError::SC64_FIRMWAREUNSUPPORTED = e {
-                                                errors.push(ConnectError::UnknownCommand(datatype));
-                                            } else {
-                                                errors.push(ConnectError::DeviceError(e));
+                                            match e {
+                                                DeviceError::SC64_FIRMWAREUNSUPPORTED => errors.push(ConnectError::UnknownCommand(datatype)),
+                                                DeviceError::FILEREADFAIL => errors.push(ConnectError::PlayerId),
+                                                _ => errors.push(ConnectError::DeviceError(e))
                                             }
                                             dbg_println!("Error processing data from N64, {:?}", e);
                                             messages.push(Message::FlashcartCommError(Arc::new(errors)));
@@ -797,31 +817,31 @@ impl Recipe for Subscription {
                 FlashcartState::INITIALIZE => {
                     n64flashcart::initialize();
                     n64flashcart::set_protocol(ProtocolVer::VERSION2);
-                    Some(FlashcartState::SEARCHING(FlashcartCache { player_data: HashMap::default() }))
+                    Some(FlashcartState::SEARCHING{data_cache: FlashcartCache { player_data: HashMap::default() }})
                 },
-                FlashcartState::DISCONNECTED(cache) => {
+                FlashcartState::DISCONNECTED{data_cache} => {
                     log_println!(log, "Flashcart: waiting 5 seconds before next scan");
                     let _ = sleep(Duration::from_secs(5)).await;
-                    Some(FlashcartState::SEARCHING(cache.to_owned()))
+                    Some(FlashcartState::SEARCHING{data_cache: data_cache.to_owned()})
                 },
-                FlashcartState::SEARCHING(cache) => {
+                FlashcartState::SEARCHING{data_cache} => {
                     if let Some(attached_device) = device {
                         let status = n64flashcart::connect(attached_device.vid, attached_device.pid, &attached_device.serial);
                         if status == DeviceError::CARTFINDFAIL {
                             n64flashcart::initialize();
                             n64flashcart::set_protocol(ProtocolVer::VERSION2);
-                            Some(FlashcartState::DISCONNECTED(cache.to_owned()))
+                            Some(FlashcartState::DISCONNECTED{data_cache: data_cache.to_owned()})
                         } else if status != DeviceError::OK {
-                            Some(FlashcartState::DISCONNECTED(cache.to_owned()))
+                            Some(FlashcartState::DISCONNECTED{data_cache: data_cache.to_owned()})
                         } else {
                             let cart_name = n64flashcart::cart_type_to_str(n64flashcart::get_cart());
-                            Some(FlashcartState::OPENING(cart_name.to_string(), cache.to_owned()))
+                            Some(FlashcartState::OPENING{cart_name: cart_name.to_string(), data_cache: data_cache.to_owned()})
                         }
                     } else {
                         None
                     }
                 },
-                FlashcartState::OPENING(name, cache) => {
+                FlashcartState::OPENING{cart_name, data_cache} => {
                     if let Some(_) = device {
                         let status = n64flashcart::open();
                         if status != DeviceError::OK {
@@ -829,43 +849,63 @@ impl Recipe for Subscription {
                             if status == DeviceError::CANTOPEN {
                                 messages.push(Message::FlashcartLocked);
                             }
-                            Some(FlashcartState::DISCONNECTED(cache.to_owned()))
+                            Some(FlashcartState::DISCONNECTED{data_cache: data_cache.to_owned()})
                         } else {
                             dbg_println!("Flashcart USB connection opened");
-                            Some(FlashcartState::CONNECTED(name.to_owned(), CommState::WaitForGame, cache.to_owned(), Arc::new(FlashcartGuard)))
+                            Some(FlashcartState::CONNECTED{
+                                cart_name: cart_name.to_owned(),
+                                connection_state: CommState::WaitForGame,
+                                data_cache: data_cache.to_owned(),
+                                disconnect_guard: Arc::new(FlashcartGuard),
+                            })
                         }
                     } else {
-                        Some(FlashcartState::SEARCHING(cache.to_owned()))
+                        Some(FlashcartState::SEARCHING{data_cache: data_cache.to_owned()})
                     }
                 },
-                FlashcartState::CONNECTED(name, comm_state, cache, guard) => {
+                FlashcartState::CONNECTED{cart_name, connection_state, data_cache, disconnect_guard} => {
                     if let Some(_) = device {
-                        match read(comm_state, cache).await {
+                        match read(connection_state, data_cache).await {
                             Ok((next_state, m)) => {
                                 messages.extend(m);
-                                match comm_state {
-                                    CommState::Ready(_struc) => {
+                                match connection_state {
+                                    CommState::Ready{game_state} => {
                                         match next_state {
-                                            Some(ready_state @ CommState::Ready(_)) => Some(FlashcartState::CONNECTED(name.to_owned(), ready_state, cache.to_owned(), guard.to_owned())),
+                                            Some(ready_state @ CommState::Ready{ .. }) => Some(FlashcartState::CONNECTED{
+                                                cart_name: cart_name.to_owned(),
+                                                connection_state: ready_state,
+                                                data_cache: data_cache.to_owned(),
+                                                disconnect_guard: disconnect_guard.to_owned(),
+                                            }),
                                             Some(CommState::Disconnect) => {
-                                                let struc = _struc.lock().await;
-                                                let mut new_cache = cache.to_owned();
+                                                let struc = game_state.lock().await;
+                                                let mut new_cache = data_cache.to_owned();
                                                 new_cache.player_data = struc.player_data.clone();
-                                                Some(FlashcartState::DISCONNECTED(new_cache))
+                                                Some(FlashcartState::DISCONNECTED{data_cache: new_cache})
                                             },
                                             Some(new_state) => {
-                                                let struc = _struc.lock().await;
-                                                let mut new_cache = cache.to_owned();
+                                                let struc = game_state.lock().await;
+                                                let mut new_cache = data_cache.to_owned();
                                                 new_cache.player_data = struc.player_data.clone();
-                                                Some(FlashcartState::CONNECTED(name.to_owned(), new_state, new_cache, guard.to_owned()))
+                                                Some(FlashcartState::CONNECTED{
+                                                    cart_name: cart_name.to_owned(),
+                                                    connection_state: new_state,
+                                                    data_cache: new_cache,
+                                                    disconnect_guard: disconnect_guard.to_owned(),
+                                                })
                                             },
                                             None => None,
                                         }
                                     },
                                     _ => {
                                         match next_state {
-                                            Some(CommState::Disconnect) => Some(FlashcartState::DISCONNECTED(cache.to_owned())),
-                                            Some(new_state) => Some(FlashcartState::CONNECTED(name.to_owned(), new_state, cache.to_owned(), guard.to_owned())),
+                                            Some(CommState::Disconnect) => Some(FlashcartState::DISCONNECTED{data_cache: data_cache.to_owned()}),
+                                            Some(new_state) => Some(FlashcartState::CONNECTED{
+                                                cart_name: cart_name.to_owned(),
+                                                connection_state: new_state,
+                                                data_cache: data_cache.to_owned(),
+                                                disconnect_guard: disconnect_guard.to_owned(),
+                                            }),
                                             None => None,
                                         }
                                     }
@@ -873,11 +913,16 @@ impl Recipe for Subscription {
                             },
                             Err(e) => {
                                 messages.push(Message::FlashcartCommError(Arc::new(vec![ConnectError::DeviceError(e)])));
-                                Some(FlashcartState::CONNECTED(name.to_owned(), comm_state.to_owned(), cache.to_owned(), guard.to_owned()))
+                                Some(FlashcartState::CONNECTED{
+                                    cart_name: cart_name.to_owned(),
+                                    connection_state: connection_state.to_owned(),
+                                    data_cache: data_cache.to_owned(),
+                                    disconnect_guard: disconnect_guard.to_owned(),
+                                })
                             }
                         }
                     } else {
-                        Some(FlashcartState::SEARCHING(cache.to_owned()))
+                        Some(FlashcartState::SEARCHING{data_cache: data_cache.to_owned()})
                     }
                 }
             };

--- a/crate/multiworld-gui/src/flashcart.rs
+++ b/crate/multiworld-gui/src/flashcart.rs
@@ -63,7 +63,7 @@ macro_rules! dbg_println {
     };
 }
 
-const PROTOCOL_VERSION: u8 = 2;
+const PROTOCOL_VERSION: u8 = 3;
 const MW_SEND_OWN_ITEMS: u8 = 1;
 const MW_PROGRESSIVE_ITEMS_ENABLE: u8 = 1;
 

--- a/crate/multiworld-gui/src/flashcart.rs
+++ b/crate/multiworld-gui/src/flashcart.rs
@@ -76,7 +76,7 @@ pub enum FlashcartState {
     CONNECTED(String, CommState)
 }
 
-const FIVE_SECONDS : Duration = Duration::new(5, 0);
+const FIVE_SECONDS : Duration = Duration::new(0, 1000000);
 
 fn send_handshake() {
     let msg = "cmdt".as_bytes().to_vec();
@@ -317,7 +317,7 @@ async fn read(name: &String, comm_state: &CommState) -> (Option<FlashcartState>,
             }
 
             select! {
-                n64_or_timeout = timeout(Duration::from_secs(5), n64_recv()) => {
+                n64_or_timeout = timeout(Duration::from_millis(10), n64_recv()) => {
                     match n64_or_timeout {
                         Ok(n64_result) => {
                             match n64_result {
@@ -403,7 +403,7 @@ impl Recipe for Subscription {
 
     fn stream(self: Box<Self>, _: EventStream) -> Pin<Box<dyn Stream<Item = Message> + Send>> {
         stream::try_unfold(FlashcartState::SEARCHING, |state| async move {
-            let _ = sleep(Duration::from_millis(100)).await;
+            let _ = sleep(Duration::from_millis(1)).await;
             let mut messages: Vec<Message> = Vec::new();
 
             let new_state = match &state {

--- a/crate/multiworld-gui/src/flashcart.rs
+++ b/crate/multiworld-gui/src/flashcart.rs
@@ -45,7 +45,6 @@ use {
         collections::HashMap,
         hash::Hash as _,
         io::prelude::*,
-        mem,
         num::NonZeroU8,
         pin::Pin,
         sync::Arc,
@@ -178,6 +177,11 @@ async fn n64_recv() -> Result<(n64flashcart::Header, Vec<u8>), DeviceError> {
         let res = spawn_blocking(|| n64flashcart::read()).await.expect("flashcart read panic");
         match res {
             Ok((header, data)) if header.datatype != USBDataType::EMPTY => {
+                match header.datatype {
+                    USBDataType::INGAME_STATE => dbg_println!("< RECV < Datatype: {:?}, Length: {}", header.datatype, header.length),
+                    USBDataType::HEARTBEAT => dbg_println!("< RECV < Heartbeat"),
+                    _ => dbg_println!("< RECV < Datatype: {:?}, Length: {}, data: {:?}", header.datatype, header.length, data)
+                };
                 return Ok((header, data));
             }
             Ok(_) => {
@@ -189,6 +193,7 @@ async fn n64_recv() -> Result<(n64flashcart::Header, Vec<u8>), DeviceError> {
 }
 
 async fn n64_send(datatype: USBDataType, msg: Vec<u8>) -> Result<(), DeviceError> {
+    dbg_println!("> SEND > Datatype: {:?}, Length: {}, data: {:?}", datatype, msg.len(), msg);
     let header = n64flashcart::Header { datatype: datatype, length: msg.len() };
     let status = spawn_blocking(|| n64flashcart::write(header, msg)).await.expect("flashcart send panic");
     match status {
@@ -257,11 +262,6 @@ async fn send_item(item: u16) -> Result<(), DeviceError> {
 async fn process_n64_packet(header: n64flashcart::Header, data: Vec<u8>, struc: &mut InGameStruct) -> Result<(Option<InGameState>, Option<Vec<Message>>), DeviceError>
 {
     match header.datatype {
-        USBDataType::INGAME_STATE => dbg_println!("Datatype: {:?}, Length: {}", header.datatype, header.length),
-        _ => dbg_println!("Datatype: {:?}, Length: {}, data: {:?}", header.datatype, header.length, data)
-    };
-
-    match header.datatype {
         USBDataType::HANDSHAKE | USBDataType::RESET => {
             Ok((Some(InGameState::NotKnown), None))
         },
@@ -308,8 +308,8 @@ async fn process_n64_packet(header: n64flashcart::Header, data: Vec<u8>, struc: 
                 let item_pending = if let InGameState::InGame { item_pending, .. } = struc.ingame_state {
                     item_pending
                 } else {
-                    for (world, (name, progressive_items)) in mem::take(&mut struc.player_data) {
-                        let _ = send_player_data(world, name, progressive_items);
+                    for (world, (name, progressive_items)) in struc.player_data.clone() {
+                        let _ = send_player_data(world, name, progressive_items).await;
                     }
                     get_item(&struc.item_queue, &mut internal_count).await?
                 };
@@ -606,12 +606,12 @@ async fn read(comm_state: &CommState) -> Result<(Option<CommState>, Vec<Message>
                         ServerMessage::PlayerName(world, new_name) => {
                             let (name, progressive_items) = struc.player_data.entry(world).or_default();
                             *name = new_name;
-                            let _ = send_player_data(world, *name, *progressive_items);
+                            let _ = send_player_data(world, *name, *progressive_items).await;
                         },
                         ServerMessage::ProgressiveItems(world, new_progressive_items) => {
                             let (name, progressive_items) = struc.player_data.entry(world).or_default();
                             *progressive_items = new_progressive_items;
-                            let _ = send_player_data(world, *name, *progressive_items);
+                            let _ = send_player_data(world, *name, *progressive_items).await;
                         },
                     }
                     None

--- a/crate/multiworld-gui/src/flashcart.rs
+++ b/crate/multiworld-gui/src/flashcart.rs
@@ -358,6 +358,9 @@ async fn process_n64_packet(header: n64flashcart::Header, data: Vec<u8>, struc: 
             }
         }
 
+        USBDataType::HEARTBEAT => Ok((None, None)),
+        USBDataType::EMPTY => Ok((None, None)),
+
         _ => {
             Err(DeviceError::SC64_FIRMWAREUNSUPPORTED)
         }
@@ -422,6 +425,7 @@ async fn read(name: &String, comm_state: &CommState) -> Result<(Option<Flashcart
                         USBDataType::HANDSHAKE | USBDataType::RESET => {
                             Some(FlashcartState::CONNECTED(name.to_owned(), CommState::SendHandshake))
                         },
+                        USBDataType::EMPTY => None,
                         _ => {
                             send_reset();
                             None
@@ -475,7 +479,7 @@ async fn read(name: &String, comm_state: &CommState) -> Result<(Option<Flashcart
 
                         Some(FlashcartState::CONNECTED(name.to_owned(), CommState::Ready(Arc::new(Mutex::new(struc)))))
                     } else if errors.is_empty() {
-                        Some(FlashcartState::CONNECTED(name.to_owned(), CommState::Handshake))
+                        None
                     } else {
                         messages.push(Message::FlashcartHandshakeFailed(Arc::new(errors)));
                         Some(FlashcartState::CONNECTED(name.to_owned(), CommState::WaitForGame))

--- a/crate/multiworld-gui/src/flashcart.rs
+++ b/crate/multiworld-gui/src/flashcart.rs
@@ -414,9 +414,8 @@ async fn process_n64_packet(header: n64flashcart::Header, data: Vec<u8>, struc: 
         },
 
         USBDataType::DUNGEON_REWARDS => {
-            if let Ok(rewarddata) = TryInto::<[u8 ; 19]>::try_into(data) {
+            if let Ok(rewarddata) = TryInto::<[u8 ; 18]>::try_into(data) {
                 let [
-                    _,
                     emerald_world,
                     emerald_area,
                     ruby_world,

--- a/crate/multiworld-gui/src/flashcart.rs
+++ b/crate/multiworld-gui/src/flashcart.rs
@@ -97,6 +97,8 @@ pub(crate) enum ConnectError {
     UnknownReplyLength(usize),
     #[error("failed to reply to handshake")]
     FailedReply,
+    #[error("no reply from the console")]
+    NoMessage,
     #[error("unhandled device error: {0:x?}")]
     DeviceError(DeviceError),
     #[error("received unknown message {0} from flashcart")]
@@ -363,6 +365,9 @@ async fn process_n64_packet(header: n64flashcart::Header, data: Vec<u8>, struc: 
 }
 
 fn process_handshake(header: n64flashcart::Header, data: Vec<u8>) -> Result<HandshakeResponse, ConnectError> {
+    if header.datatype == USBDataType::EMPTY {
+        return Err(ConnectError::NoMessage);
+    }
     if header.datatype != USBDataType::HANDSHAKE {
         return Err(ConnectError::UnknownReplyHeader(header.datatype));
     }
@@ -443,7 +448,12 @@ async fn read(name: &String, comm_state: &CommState) -> Result<(Option<Flashcart
                             response = Some(resp);
                         }
                         Err(e) => {
-                            errors.push((name.to_owned(), e));
+                            match e {
+                                ConnectError::NoMessage => {}
+                                _ => {
+                                    errors.push((name.to_owned(), e));
+                                }
+                            }
                         }
                     }
                     if let Some(HandshakeResponse { version, player_id, file_hash }) = response {
@@ -464,6 +474,8 @@ async fn read(name: &String, comm_state: &CommState) -> Result<(Option<Flashcart
                         };
 
                         Some(FlashcartState::CONNECTED(name.to_owned(), CommState::Ready(Arc::new(Mutex::new(struc)))))
+                    } else if errors.is_empty() {
+                        Some(FlashcartState::CONNECTED(name.to_owned(), CommState::Handshake))
                     } else {
                         messages.push(Message::FlashcartHandshakeFailed(Arc::new(errors)));
                         Some(FlashcartState::CONNECTED(name.to_owned(), CommState::WaitForGame))

--- a/crate/multiworld-gui/src/flashcart.rs
+++ b/crate/multiworld-gui/src/flashcart.rs
@@ -1,15 +1,68 @@
 use {
-    crate::{FrontendWriter, Message}, arrayref::{array_mut_ref, array_ref}, enum_iterator::all, futures::{TryStreamExt as _, stream::{
+    crate::{
+        FrontendWriter,
+        Message
+    },
+    arrayref::{
+        array_mut_ref,
+        array_ref
+    },
+    chrono::prelude::*,
+    enum_iterator::all,
+    futures::{
+        TryStreamExt as _,
+        stream::{
             self,
             Stream,
             StreamExt as _,
-    }}, iced::advanced::subscription::{
+        },
+    },
+    iced::advanced::subscription::{
         EventStream,
         Recipe,
-    }, multiworld::{Filename, frontend::{ClientMessage, ServerMessage}}, n64flashcart, ootr_utils::spoiler::HashIcon, std::{
-        any::TypeId, collections::{HashMap, VecDeque}, hash::Hash as _, num::NonZeroU8, pin::Pin, sync::Arc, time::Duration
-    }, tokio::{select, sync::{Mutex, mpsc}, time::{sleep, timeout}}
+    },
+    log_lock::lock,
+    multiworld::{
+        Filename,
+        frontend::{
+            ClientMessage,
+            ServerMessage
+        },
+        HintArea,
+        OptHintArea,
+    },
+    n64flashcart::{
+        self,
+        DeviceError,
+        ProtocolVer,
+        USBDataType,
+    },
+    num_traits::FromPrimitive as _,
+    ootr_utils::spoiler::HashIcon,
+    std::{
+        any::TypeId,
+        collections::HashMap,
+        hash::Hash as _,
+        io::prelude::*,
+        mem,
+        num::NonZeroU8,
+        pin::Pin,
+        sync::Arc,
+        time::Duration
+    },
+    tokio::{
+        select,
+        sync::{
+            Mutex,
+            mpsc
+        },
+        time::{
+            sleep,
+            timeout
+        }
+    },
 };
+#[cfg(unix)] use std::ffi::OsString;
 
 const DEBUG_LOGGING: bool = true;
 
@@ -21,40 +74,61 @@ macro_rules! dbg_println {
     };
 }
 
-const PROTOCOL_VERSION: u8 = 1;
+const PROTOCOL_VERSION: u8 = 2;
 const MW_SEND_OWN_ITEMS: u8 = 1;
 const MW_PROGRESSIVE_ITEMS_ENABLE: u8 = 1;
 
-const CMD_PLAYER_DATA: u8 = 1;
-const CMD_GET_ITEM: u8 = 2;
-const N64_ITEM_SEND: u8 = 3;
-const N64_ITEM_RECEIVED: u8 = 4;
-
 #[derive(Debug, thiserror::Error)]
-pub(crate) enum Error {
-    #[error("Flashcart disconnected")]
-    #[expect(dead_code)]
-    Disconnected,
+pub(crate) enum ConnectError {
+    #[error("unknown branch identifier: 0x{0:02x}")]
+    Branch(u8),
+    #[error("failed to decode hash icon")]
+    HashIcon,
+    #[cfg(unix)]
+    #[error("non-UTF-8 string: {}", .0.to_string_lossy())]
+    OsString(OsString),
     #[error("received item for world 0")]
     PlayerId,
+    #[error("unexpected handshake reply header: {0:x?}")]
+    UnknownReplyHeader(USBDataType),
+    #[error("unexpected handshake reply: {0:x?}")]
+    UnknownReply([u8; 4]),
+    #[error("unexpected handshake reply length: {0:x?}")]
+    UnknownReplyLength(usize),
+    #[error("failed to reply to handshake")]
+    FailedReply,
+    #[error("unhandled device error: {0:x?}")]
+    DeviceError(DeviceError),
+    #[error("received unknown message {0} from flashcart")]
+    UnknownCommand(u8),
+}
+
+#[cfg(unix)]
+impl From<OsString> for ConnectError {
+    fn from(s: OsString) -> Self {
+        Self::OsString(s)
+    }
 }
 
 pub(crate) struct Subscription {
-//    pub(crate) log: bool,
+    pub(crate) log: bool,
 }
 
 #[derive(Debug, Clone)]
 pub(crate) enum InGameState {
-    Unknown,
+    NotKnown,
     FileSelect,
-    InGame,
-    Receiving
+    InGame {
+        internal_count: u16,
+        item_pending: bool,
+    },
 }
 
 #[derive(Debug)]
 pub(crate) struct InGameStruct {
+    _version: ootr_utils::Version,
     rx: mpsc::Receiver<ServerMessage>,
-    item_queue: VecDeque<u16>,
+    item_queue: Vec<u16>,
     ingame_state: InGameState,
     filename: Option<Filename>,
     player_data: HashMap<NonZeroU8, (Filename, u32)>,
@@ -76,34 +150,18 @@ pub enum FlashcartState {
     CONNECTED(String, CommState)
 }
 
-const FIVE_SECONDS : Duration = Duration::new(0, 1000000);
-
-fn send_handshake() {
-    let msg = "cmdt".as_bytes().to_vec();
-    let header = n64flashcart::Header { datatype: n64flashcart::USBDataType::TEXT, length: msg.len() };
-
-    let _ = n64flashcart::write(header, msg);
+#[derive(Debug)]
+struct HandshakeResponse {
+    version: ootr_utils::Version,
+    player_id: NonZeroU8,
+    file_hash: [HashIcon; 5],
 }
 
-fn send_handshake_response() -> Result<(), n64flashcart::DeviceError>  {
-    let mut msg = "MW".as_bytes().to_vec();
-    msg.push(PROTOCOL_VERSION);
-    msg.push(MW_SEND_OWN_ITEMS); // MW_SEND_OWN_ITEMS
-    msg.push(MW_PROGRESSIVE_ITEMS_ENABLE); // MW_PROGRESSIVE_ITEMS_ENABLE
-    let header = n64flashcart::Header { datatype: n64flashcart::USBDataType::RAWBINARY, length: msg.len() };
-    let status = n64flashcart::write(header, msg);
-    
-    match status {
-        n64flashcart::DeviceError::OK => Ok(()),
-        _ => Err(status)
-    }
-}
-
-async fn n64_recv() -> Result<(n64flashcart::Header, Vec<u8>), n64flashcart::DeviceError> {
+async fn n64_recv() -> Result<(n64flashcart::Header, Vec<u8>), DeviceError> {
     loop {
         match n64flashcart::read() {
             Ok((header, data)) => {
-                if header.datatype != n64flashcart::USBDataType::EMPTY {
+                if header.datatype != USBDataType::EMPTY {
                     return Ok((header, data));
                 }
             }
@@ -112,244 +170,388 @@ async fn n64_recv() -> Result<(n64flashcart::Header, Vec<u8>), n64flashcart::Dev
     }
 }
 
-fn n64_send(datatype: n64flashcart::USBDataType, msg: Vec<u8>) -> Result<(), n64flashcart::DeviceError> {
+fn n64_send(datatype: USBDataType, msg: Vec<u8>) -> Result<(), DeviceError> {
     let header = n64flashcart::Header { datatype: datatype, length: msg.len() };
     let status = n64flashcart::write(header, msg);
     match status {
-        n64flashcart::DeviceError::OK => Ok(()),
+        DeviceError::OK => Ok(()),
         _ => Err(status)
     }
 }
 
-fn send_player_data(world: NonZeroU8, name: Filename, progressive_items: u32) -> Result<(), n64flashcart::DeviceError> {
-    let mut buf = [0; 16];
+fn send_handshake() {
+    let msg = "cmdt".as_bytes().to_vec();
 
-    buf[0] = CMD_PLAYER_DATA;
-    buf[1] = world.get();
-    *array_mut_ref![buf, 2, 8] = name.0;
-    *array_mut_ref![buf, 10, 4] = progressive_items.to_be_bytes();
-
-    n64_send(n64flashcart::USBDataType::RAWBINARY, Vec::from(buf))
+    let _ = n64_send(USBDataType::HANDSHAKE, msg);
 }
 
-fn send_item(item: u16) -> Result<(), n64flashcart::DeviceError> {
-    let mut msg: Vec<u8> = Vec::new();
+fn send_handshake_response() -> Result<(), DeviceError> {
+    let mut msg = "MW".as_bytes().to_vec();
+    msg.push(PROTOCOL_VERSION);
+    msg.push(MW_SEND_OWN_ITEMS);
+    msg.push(MW_PROGRESSIVE_ITEMS_ENABLE);
 
-    msg.push(CMD_GET_ITEM);
+    n64_send(USBDataType::HANDSHAKE, msg)
+}
+
+fn send_reset() {
+    let msg = "cmdt".as_bytes().to_vec();
+
+    let _ = n64_send(USBDataType::RESET, msg);
+}
+
+fn send_player_data(world: NonZeroU8, name: Filename, progressive_items: u32) -> Result<(), DeviceError> {
+    let mut buf = [0; 16];
+
+    buf[0] = world.get();
+    *array_mut_ref![buf, 1, 8] = name.0;
+    *array_mut_ref![buf, 9, 4] = progressive_items.to_be_bytes();
+
+    n64_send(USBDataType::PLAYER_NAMES, Vec::from(buf))
+}
+
+async fn get_item(queue: &[u16], internal_count: &mut u16) -> Result<bool, DeviceError> {
+    if let Some(item) = queue.get(usize::from(*internal_count)) {
+        match send_item(*item) {
+            Ok(_) => {
+                *internal_count += 1;
+                Ok(true)
+            },
+            Err(_) => {
+                Ok(false)
+            }
+        }
+    } else {
+        Ok(false)
+    }
+}
+
+fn send_item(item: u16) -> Result<(), DeviceError> {
+    let mut msg: Vec<u8> = Vec::new();
 
     let [b1, b2] = item.to_be_bytes();
     msg.push(b1);
     msg.push(b2);
 
-    n64_send(n64flashcart::USBDataType::RAWBINARY, msg)
+    n64_send(USBDataType::SEND_ITEM, msg)
 }
 
-fn process_n64_packet(header: n64flashcart::Header, data: Vec<u8>, struc: &mut InGameStruct) -> (Option<InGameState>, Option<Vec<Message>>)
+async fn process_n64_packet(header: n64flashcart::Header, data: Vec<u8>, struc: &mut InGameStruct) -> Result<(Option<InGameState>, Option<Vec<Message>>), DeviceError>
 {
     match header.datatype {
-        n64flashcart::USBDataType::INGAME_STATE => dbg_println!("Datatype: {:?}, Length: {}", header.datatype, header.length),
+        USBDataType::INGAME_STATE => dbg_println!("Datatype: {:?}, Length: {}", header.datatype, header.length),
         _ => dbg_println!("Datatype: {:?}, Length: {}, data: {:?}", header.datatype, header.length, data)
     };
 
     match header.datatype {
-        n64flashcart::USBDataType::SAVE_FILENAME => {
-            if data.len() >= 9 {
+        USBDataType::HANDSHAKE | USBDataType::RESET => {
+            Ok((Some(InGameState::NotKnown), None))
+        },
+
+        USBDataType::SAVE_FILENAME => {
+            if data.len() >= 8 {
                 let data_slice = data.into_boxed_slice();
-                let fname = *array_ref![data_slice, 1, 8];
+                let filename = Filename(*array_ref![data_slice, 0, 8]);
+                struc.filename = Some(filename);
 
-                match fname {
-                    [0, 0, 0, 0, 0, 0, 0, 0] => {
-                        (Some(InGameState::FileSelect), None)
-                    },
-                    _ => {
-                        let filename = Filename(fname);
-                        if let None = struc.filename {
-                            struc.filename = Some(filename);
-                        }
-
-                        (Some(InGameState::InGame), Some(vec![Message::Plugin(Box::new(ClientMessage::PlayerName(filename)))]))
-                    }
-
-                }
-            }
-            else {
-                (None, None)
+                Ok((Some(InGameState::FileSelect), Some(vec![Message::Plugin(Box::new(ClientMessage::PlayerName(filename)))])))
+            } else {
+                Ok((None, None))
             }
         },
 
-        n64flashcart::USBDataType::INGAME_STATE => {
+        USBDataType::INGAME_STATE => {
             if let Ok(savedata) = TryInto::<[u8 ; 5200]>::try_into(data) {
                 let mut messages = Vec::new();
                 
-                if let None = struc.filename {
-                    let filename = Filename(*array_ref![savedata, 0x024, 8]);
+                let filename = Filename(*array_ref![savedata, 0x024, 8]);
+                if Some(filename) != struc.filename {
                     struc.filename = Some(filename);
                     messages.push(Message::Plugin(Box::new(ClientMessage::PlayerName(filename))));
                 }
+                let mut internal_count = u16::from_be_bytes(*array_ref![savedata, 0x90, 2]);
 
                 messages.push(Message::Plugin(Box::new(ClientMessage::SaveData(savedata))));
-
-                (Some(InGameState::InGame), Some(messages))
+                let item_pending = if let InGameState::InGame { item_pending, .. } = struc.ingame_state {
+                    item_pending
+                } else {
+                    for (world, (name, progressive_items)) in mem::take(&mut struc.player_data) {
+                        let _ = send_player_data(world, name, progressive_items);
+                    }
+                    get_item(&struc.item_queue, &mut internal_count).await?
+                };
+                Ok((Some(InGameState::InGame { internal_count, item_pending }), Some(messages)))
             } else {
-                (None, None)
-            }            
-        },
-
-        n64flashcart::USBDataType::RAWBINARY =>  {
-            match data[0] {
-                N64_ITEM_SEND => {  // Item sent
-                    let data_slice = data.into_boxed_slice();
-
-                    let kind = u16::from_be_bytes(*array_ref![data_slice, 9, 2]);
-                    let target_world = NonZeroU8::new(data_slice[11]).ok_or(Error::PlayerId).unwrap();
-
-                    dbg_println!("Got item {} for world {}", kind, target_world);
-
-                    let message = Message::Plugin(Box::new(ClientMessage::SendItem {
-                        key: u64::from_be_bytes(*array_ref![data_slice, 1, 8]),
-                        kind: kind,
-                        target_world: target_world,
-                    }));
-
-                    (None, Some(vec![message]))
-                }
-                N64_ITEM_RECEIVED => (Some(InGameState::InGame), None), // Item receive confirmation
-                _ => (None, None)
+                Ok((Some(InGameState::NotKnown), None))
             }
         },
 
-        _ => (None, None)
+        USBDataType::SEND_ITEM => {
+            if data.len() >= 11 {
+                let data_slice = data.into_boxed_slice();
+
+                let kind = u16::from_be_bytes(*array_ref![data_slice, 8, 2]);
+                let target_world = NonZeroU8::new(data_slice[10]).ok_or(ConnectError::PlayerId).unwrap();
+
+                dbg_println!("Got item {} for world {}", kind, target_world);
+
+                let message = Message::Plugin(Box::new(ClientMessage::SendItem {
+                    key: u64::from_be_bytes(*array_ref![data_slice, 0, 8]),
+                    kind: kind,
+                    target_world: target_world,
+                }));
+
+                Ok((None, Some(vec![message])))
+            } else {
+                Ok((None, None))
+            }
+        },
+
+        USBDataType::ACK_ITEM => {
+            if let InGameState::InGame { ref mut internal_count, ref mut item_pending } = struc.ingame_state {
+                if !get_item(&struc.item_queue, internal_count).await? {
+                    *item_pending = false;
+                }
+            }
+            Ok((None, None))
+        },
+
+        USBDataType::DUNGEON_REWARDS => {
+            if let Ok(rewarddata) = TryInto::<[u8 ; 19]>::try_into(data) {
+                let [
+                    _,
+                    emerald_world,
+                    emerald_area,
+                    ruby_world,
+                    ruby_area,
+                    sapphire_world,
+                    sapphire_area,
+                    light_world,
+                    light_area,
+                    forest_world,
+                    forest_area,
+                    fire_world,
+                    fire_area,
+                    water_world,
+                    water_area,
+                    shadow_world,
+                    shadow_area,
+                    spirit_world,
+                    spirit_area
+                ] = rewarddata;
+                let message = vec![Message::Plugin(Box::new(ClientMessage::DungeonRewardInfo {
+                    emerald: if let (Some(world), Some(area)) = (NonZeroU8::new(emerald_world), OptHintArea::from_u8(emerald_area).and_then(|area| HintArea::try_from(area).ok())) { Some((world, area)) } else { None },
+                    ruby: if let (Some(world), Some(area)) = (NonZeroU8::new(ruby_world), OptHintArea::from_u8(ruby_area).and_then(|area| HintArea::try_from(area).ok())) { Some((world, area)) } else { None },
+                    sapphire: if let (Some(world), Some(area)) = (NonZeroU8::new(sapphire_world), OptHintArea::from_u8(sapphire_area).and_then(|area| HintArea::try_from(area).ok())) { Some((world, area)) } else { None },
+                    light: if let (Some(world), Some(area)) = (NonZeroU8::new(light_world), OptHintArea::from_u8(light_area).and_then(|area| HintArea::try_from(area).ok())) { Some((world, area)) } else { None },
+                    forest: if let (Some(world), Some(area)) = (NonZeroU8::new(forest_world), OptHintArea::from_u8(forest_area).and_then(|area| HintArea::try_from(area).ok())) { Some((world, area)) } else { None },
+                    fire: if let (Some(world), Some(area)) = (NonZeroU8::new(fire_world), OptHintArea::from_u8(fire_area).and_then(|area| HintArea::try_from(area).ok())) { Some((world, area)) } else { None },
+                    water: if let (Some(world), Some(area)) = (NonZeroU8::new(water_world), OptHintArea::from_u8(water_area).and_then(|area| HintArea::try_from(area).ok())) { Some((world, area)) } else { None },
+                    shadow: if let (Some(world), Some(area)) = (NonZeroU8::new(shadow_world), OptHintArea::from_u8(shadow_area).and_then(|area| HintArea::try_from(area).ok())) { Some((world, area)) } else { None },
+                    spirit: if let (Some(world), Some(area)) = (NonZeroU8::new(spirit_world), OptHintArea::from_u8(spirit_area).and_then(|area| HintArea::try_from(area).ok())) { Some((world, area)) } else { None },
+                }))];
+                Ok((None, Some(message)))
+            } else {
+                Ok((None, None))
+            }
+        }
+
+        _ => {
+            Err(DeviceError::SC64_FIRMWAREUNSUPPORTED)
+        }
     }
 }
 
-fn process_message(comm_state: &CommState, header: n64flashcart::Header, data: Vec<u8>) -> (Option<CommState>, Vec<Message>) {
+fn process_handshake(header: n64flashcart::Header, data: Vec<u8>) -> Result<HandshakeResponse, ConnectError> {
+    if header.datatype != USBDataType::HANDSHAKE {
+        return Err(ConnectError::UnknownReplyHeader(header.datatype));
+    }
+    let data_size = data.len();
+    match TryInto::<[u8 ; 16]>::try_into(data) {
+        Ok(value) => {
+            match value {
+                [b'O', b'o', b'T', b'R', PROTOCOL_VERSION, major, minor, patch, branch, supplementary, player_id, hash1, hash2, hash3, hash4, hash5] => {
+                    dbg_println!("Handshake reply received. Repeating protocol version to finalize handshake");
+                    match send_handshake_response() {
+                        Ok(_) => {
+                            dbg_println!("Protocol version sent");
+
+                            let version = ootr_utils::Version::from_bytes([major, minor, patch, branch, supplementary]).ok_or_else(|| ConnectError::Branch(branch))?;
+                            let player_id = NonZeroU8::new(player_id).ok_or(ConnectError::PlayerId)?;
+                            let file_hash: [HashIcon; 5] = [
+                                all().nth(hash1.into()).ok_or(ConnectError::HashIcon)?,
+                                all().nth(hash2.into()).ok_or(ConnectError::HashIcon)?,
+                                all().nth(hash3.into()).ok_or(ConnectError::HashIcon)?,
+                                all().nth(hash4.into()).ok_or(ConnectError::HashIcon)?,
+                                all().nth(hash5.into()).ok_or(ConnectError::HashIcon)?,
+                            ];
+                            
+                            Ok(HandshakeResponse { version: version, player_id, file_hash })
+                        },
+                        Err(_) => {
+                            dbg_println!("Failed to send protocol version, restarting handshake");
+                            Err(ConnectError::FailedReply)
+                        }
+                    }
+                },
+                _ => {
+                    dbg_println!("Invalid handshake reply, restarting handshake");
+                    Err(ConnectError::UnknownReply(value[0..4].try_into().unwrap()))
+                }
+            } 
+        },
+        Err(_) => {
+            dbg_println!("Invalid handshake length, restarting handshake");
+            Err(ConnectError::UnknownReplyLength(data_size))
+        }
+    }
+}
+
+async fn read(name: &String, comm_state: &CommState) -> Result<(Option<FlashcartState>, Vec<Message>), DeviceError> {
     let mut messages = Vec::new();
-    let next_comm_state = match comm_state {
-        CommState::SendHandshake => {
-            send_handshake();
-            Some(CommState::Handshake)
-        }
+    let next_state = match comm_state {
         CommState::WaitForGame => {
-            if header.datatype == n64flashcart::USBDataType::HANDSHAKE {
-                Some(CommState::SendHandshake)
-            } else {
-                None
-            }
-        }
-        CommState::Handshake => {
-            match TryInto::<[u8 ; 16]>::try_into(data) {
-                Ok(value) => {
-                    match value {
-                        [b'O', b'o', b'T', b'R', PROTOCOL_VERSION, major, minor, patch, branch, supplementary, player_id, hash1, hash2, hash3, hash4, hash5] => {
-                            dbg_println!("Handshake reply received. Repeating protocol version to finalize handshake");
-                            let res = send_handshake_response();
-                            match res {
-                                Ok(_) => {
-                                    dbg_println!("Protocol version sent");
-
-                                    let _version = ootr_utils::Version::from_bytes([major, minor, patch, branch, supplementary]).unwrap();
-                                    let player_id = NonZeroU8::new(player_id).unwrap();
-                                    let file_hash: [HashIcon; 5] = [
-                                        all().nth(hash1.into()).unwrap(),
-                                        all().nth(hash2.into()).unwrap(),
-                                        all().nth(hash3.into()).unwrap(),
-                                        all().nth(hash4.into()).unwrap(),
-                                        all().nth(hash5.into()).unwrap(),
-                                    ];
-                                    
-                                    let (tx, rx) = mpsc::channel(1_024);
-
-                                    messages.push(Message::FrontendConnected(FrontendWriter::Mpsc(tx)));
-                                    messages.push(Message::Plugin(Box::new(ClientMessage::PlayerId(player_id))));
-                                    messages.push(Message::Plugin(Box::new(ClientMessage::FileHash(Some(file_hash)))));
-
-                                    let struc = InGameStruct {
-                                        rx: rx,
-                                        item_queue: VecDeque::new(),
-                                        ingame_state: InGameState::Unknown,
-                                        filename: None,
-                                        player_data: HashMap::default()
-                                    };
-
-                                    Some(CommState::Ready(Arc::new(Mutex::new(struc))))
-                                },
-                                Err(_) => {
-                                    dbg_println!("Failed to send protocol version, restarting handshake");
-                                    Some(CommState::WaitForGame)
-                                }
-                            }
+            match n64flashcart::read() {
+                Ok((header, _data)) => {
+                    match header.datatype {
+                        USBDataType::HANDSHAKE | USBDataType::RESET => {
+                            Some(FlashcartState::CONNECTED(name.to_owned(), CommState::SendHandshake))
                         },
                         _ => {
-                            dbg_println!("Invalid handshake reply, restarting handshake");
-                            Some(CommState::WaitForGame)
+                            send_reset();
+                            None
                         }
-                    } 
-                },
-                Err(_) => {
-                    dbg_println!("Invalid handshake reply, restarting handshake");
-                    Some(CommState::WaitForGame)
+                    }
+                }
+                Err(e) => {
+                    dbg_println!("Read error while waiting for handshake, {}", e.value());
+                    Some(FlashcartState::DISCONNECTED)
                 }
             }
         },
-        CommState::Ready(_) => None,
-    };
-
-    (next_comm_state, messages)
-}
-
-async fn read(name: &String, comm_state: &CommState) -> (Option<FlashcartState>, Vec<Message>) {
-    let next_state = match comm_state {
         CommState::SendHandshake => {
             send_handshake();
             Some(FlashcartState::CONNECTED(name.to_owned(), CommState::Handshake))
         },
-        CommState::Ready(_struc) => {
-            let mut struc = _struc.lock().await;
-            let mut messages = Vec::new();
+        CommState::Handshake => {
+            match n64flashcart::read() {
+                Ok((header, data)) => {
+                    let mut response = None;
+                    let mut errors = Vec::default();
+                    match process_handshake(header, data) {
+                        Ok(resp) => {
+                            response = Some(resp);
+                        }
+                        Err(e) => {
+                            errors.push((name.to_owned(), e));
+                        }
+                    }
+                    if let Some(HandshakeResponse { version, player_id, file_hash }) = response {
+                        let (tx, rx) = mpsc::channel(1_024);
 
-            if !struc.item_queue.is_empty() {
-                if let InGameState::InGame = struc.ingame_state {
-                    let item = struc.item_queue.pop_front().unwrap();
-                    let _ = send_item(item);
+                        messages.push(Message::FrontendConnected(FrontendWriter::Mpsc(tx)));
+                        messages.push(Message::Plugin(Box::new(ClientMessage::PlayerId(player_id))));
+                        messages.push(Message::Plugin(Box::new(ClientMessage::FileHash(Some(file_hash)))));
+                        messages.push(Message::FlashcartHandshakeSuccessful());
 
-                    struc.ingame_state = InGameState::Receiving;
+                        let struc = InGameStruct {
+                            _version: version,
+                            rx: rx,
+                            item_queue: Vec::default(),
+                            ingame_state: InGameState::NotKnown,
+                            filename: None,
+                            player_data: HashMap::default()
+                        };
+
+                        Some(FlashcartState::CONNECTED(name.to_owned(), CommState::Ready(Arc::new(Mutex::new(struc)))))
+                    } else {
+                        messages.push(Message::FlashcartHandshakeFailed(Arc::new(errors)));
+                        Some(FlashcartState::CONNECTED(name.to_owned(), CommState::WaitForGame))
+                    }
+                }
+                Err(e) => {
+                    dbg_println!("Read error while finalizing for handshake, {}", e.value());
+                    Some(FlashcartState::DISCONNECTED)
                 }
             }
+        },
+        CommState::Ready(_struc) => {
+            let mut struc = _struc.lock().await;
+
+            dbg_println!("InGameState: {:?}", struc.ingame_state);
 
             select! {
-                n64_or_timeout = timeout(Duration::from_millis(10), n64_recv()) => {
+                n64_or_timeout = timeout(Duration::from_secs(10), n64_recv()) => {
                     match n64_or_timeout {
                         Ok(n64_result) => {
                             match n64_result {
                                 Ok((header, data)) => {
-                                    let (state_, messages_) = process_n64_packet(header, data, &mut struc);
-                                    if let Some(value) = state_ {
-                                        struc.ingame_state = value;
-                                    }
-                                    if let Some(msg) = messages_ {
-                                        messages.extend(msg);
+                                    let datatype = header.datatype.value();
+                                    match process_n64_packet(header, data, &mut struc).await {
+                                        Ok((state_, messages_)) => {
+                                            if let Some(msg) = messages_ {
+                                                messages.extend(msg);
+                                            }
+                                            if let Some(InGameState::NotKnown) = state_ {
+                                                Some(FlashcartState::CONNECTED(name.to_owned(), CommState::WaitForGame))
+                                            } else if let Some(value) = state_ {
+                                                struc.ingame_state = value;
+                                                None
+                                            } else {
+                                                None
+                                            }
+                                        }
+                                        Err(e) => {
+                                            let mut errors = Vec::default();
+                                            if let DeviceError::SC64_FIRMWAREUNSUPPORTED = e {
+                                                errors.push((name.to_owned(), ConnectError::UnknownCommand(datatype)));
+                                            } else {
+                                                errors.push((name.to_owned(), ConnectError::DeviceError(e)));
+                                            }
+                                            dbg_println!("Error processing data from N64, {:?}", e);
+                                            messages.push(Message::FlashcartCommError(Arc::new(errors)));
+                                            None
+                                        }
                                     }
                                 },
                                 Err(e) => {
-                                    dbg_println!("Error receiving from n64, {:?}", e);
-                                    return (Some(FlashcartState::DISCONNECTED), vec![]);
+                                    dbg_println!("Error receiving from N64, {:?}", e);
+                                    let errors = vec![(name.to_owned(), ConnectError::DeviceError(e))];
+                                    messages.push(Message::FlashcartCommError(Arc::new(errors)));
+                                    Some(FlashcartState::DISCONNECTED)
                                 }
                             }
                         },
                         Err(_) => {
-                            dbg_println!("No message from N64 in 5 seconds");
-                            return (Some(FlashcartState::DISCONNECTED), vec![]);
+                            dbg_println!("No message from N64 in 10 seconds");
+                            Some(FlashcartState::DISCONNECTED)
                         }
-                    };
+                    }
                 },
                 Some(msg) = struc.rx.recv() => {
                     dbg_println!("Received message from MH, {:?}", msg);
                     match msg {
                         ServerMessage::ItemQueue(items) => {
-                            struc.item_queue.extend(items);
+                            struc.item_queue = items;
+                            let item_queue = struc.item_queue.clone();
+                            if let InGameState::InGame { ref mut internal_count, ref mut item_pending } = struc.ingame_state {
+                                if !*item_pending {
+                                    if let Ok(true) = get_item(&item_queue, internal_count).await {
+                                        *item_pending = true;
+                                    }
+                                }
+                            }
                         },
                         ServerMessage::GetItem(item) => {
-                            struc.item_queue.push_back(item);
+                            struc.item_queue.push(item);
+                            let item_queue = struc.item_queue.clone();
+                            if let InGameState::InGame { ref mut internal_count, ref mut item_pending } = struc.ingame_state {
+                                if !*item_pending {
+                                    if let Ok(true) = get_item(&item_queue, internal_count).await {
+                                        *item_pending = true;
+                                    }
+                                }
+                            }
                         },
                         ServerMessage::PlayerName(world, new_name) => {
                             let (name, progressive_items) = struc.player_data.entry(world).or_default();
@@ -362,36 +564,13 @@ async fn read(name: &String, comm_state: &CommState) -> (Option<FlashcartState>,
                             let _ = send_player_data(world, *name, *progressive_items);
                         },
                     }
-                    
-                }
-            };
-            
-            dbg_println!("InGameState: {:?}", struc.ingame_state);
-            return (None, messages);
-        },
-        _ => {
-            match n64flashcart::read() {
-                Ok((header, data)) => {
-                    if header.datatype == n64flashcart::USBDataType::EMPTY {
-                        // Do nothing, no data
-                        None
-                    }
-                    else {
-                        let (new_comm_state, messages) = process_message(comm_state, header, data);
-                        let next_state = new_comm_state.map(|state| FlashcartState::CONNECTED(name.to_owned(), state));
-                        return (next_state, messages);
-                    }
-                }
-                Err(e) => {
-                    dbg_println!("Read error while waiting for handshake, {}", e.value());
-                    //sleep(FIVE_SECONDS).await;
-                    Some(FlashcartState::DISCONNECTED)
+                    None
                 }
             }
         }
     };
 
-    (next_state, vec![])
+    Ok((next_state, messages))
 }
 
 impl Recipe for Subscription {
@@ -402,21 +581,29 @@ impl Recipe for Subscription {
     }
 
     fn stream(self: Box<Self>, _: EventStream) -> Pin<Box<dyn Stream<Item = Message> + Send>> {
-        stream::try_unfold(FlashcartState::SEARCHING, |state| async move {
+        let log = self.log || DEBUG_LOGGING;
+        stream::try_unfold(FlashcartState::SEARCHING, move |state| async move {
             let _ = sleep(Duration::from_millis(1)).await;
             let mut messages: Vec<Message> = Vec::new();
 
             let new_state = match &state {
                 FlashcartState::DISCONNECTED => {
-                    let _ = sleep(FIVE_SECONDS).await;
+                    if log {
+                        let _ = lock!(log = crate::LOG; writeln!(&*log, "{} EverDrive: waiting 5 seconds before next scan", Utc::now().format("%Y-%m-%d %H:%M:%S")));
+                    }
+                    if n64flashcart::isopen() {
+                        n64flashcart::close();
+                    }
+                    let _ = sleep(Duration::from_secs(5)).await;
                     Some(FlashcartState::SEARCHING)
                 },
                 FlashcartState::SEARCHING => {
                     let status = n64flashcart::find();
-                    if status == n64flashcart::DeviceError::CARTFINDFAIL {
+                    if status == DeviceError::CARTFINDFAIL {
                         n64flashcart::initialize();
+                        n64flashcart::set_protocol(ProtocolVer::VERSION2);
                         Some(FlashcartState::DISCONNECTED)
-                    } else if status != n64flashcart::DeviceError::OK {
+                    } else if status != DeviceError::OK {
                         Some(FlashcartState::DISCONNECTED)
                     } else {
                         let cart_name = n64flashcart::cart_type_to_str(n64flashcart::get_cart());
@@ -425,18 +612,25 @@ impl Recipe for Subscription {
                 },
                 FlashcartState::OPENING(name) => {
                     let status = n64flashcart::open();
-                    if status != n64flashcart::DeviceError::OK {
+                    if status != DeviceError::OK {
                         dbg_println!("Failed to open USB connection to flashcart, retrying, error code {}", status.value());
                         Some(FlashcartState::DISCONNECTED)
                     } else {
                         dbg_println!("Flashcart USB connection opened");
-                        Some(FlashcartState::CONNECTED(name.to_owned(), CommState::SendHandshake))
-                    }    
+                        Some(FlashcartState::CONNECTED(name.to_owned(), CommState::WaitForGame))
+                    }
                 },
                 FlashcartState::CONNECTED(name, comm_state) => {
-                    let (next_state, m) = read(name, comm_state).await;
-                    messages.extend(m);
-                    next_state
+                    match read(name, comm_state).await {
+                        Ok((next_state, m)) => {
+                            messages.extend(m);
+                            next_state
+                        },
+                        Err(e) => {
+                            messages.push(Message::FlashcartCommError(Arc::new(vec![(name.to_owned(), ConnectError::DeviceError(e))])));
+                            Some(FlashcartState::CONNECTED(name.to_owned(), comm_state.to_owned()))
+                        }
+                    }
                 }
             };
 
@@ -444,7 +638,7 @@ impl Recipe for Subscription {
                 messages.push(Message::FlashcartStateChanged(value.clone()));
             }
 
-            Ok::<_, Error>(Some((stream::iter(messages).map(Ok::<_, Error>), new_state.unwrap_or(state))))
+            Ok::<_, ConnectError>(Some((stream::iter(messages).map(Ok::<_, ConnectError>), new_state.unwrap_or(state))))
         }).try_flatten().map(|res| {
             let mut print_debug = true;
 

--- a/crate/multiworld-gui/src/flashcart.rs
+++ b/crate/multiworld-gui/src/flashcart.rs
@@ -3,54 +3,42 @@ use {
         FrontendWriter,
         Message,
         UsbSerialPort,
-    },
-    arrayref::{
+    }, arrayref::{
         array_mut_ref,
         array_ref
-    },
-    chrono::prelude::*,
-    enum_iterator::all,
-    futures::{
+    }, chrono::prelude::*, enum_iterator::all, futures::{
         TryStreamExt as _,
         stream::{
             self,
             Stream,
             StreamExt as _,
         },
-    },
-    iced::advanced::subscription::{
+    }, iced::advanced::subscription::{
         EventStream,
         Recipe,
-    },
-    log_lock::lock,
-    multiworld::{
-        Filename,
-        frontend::{
+    }, log_lock::lock, multiworld::{
+        Filename, HintArea, OptHintArea, frontend::{
             ClientMessage,
             ServerMessage
-        },
-        HintArea,
-        OptHintArea,
-    },
-    n64flashcart::{
+        }
+    }, n64flashcart::{
         self,
         DeviceError,
         ProtocolVer,
         USBDataType,
-    },
-    num_traits::FromPrimitive as _,
-    ootr_utils::spoiler::HashIcon,
-    std::{
+    }, num_traits::FromPrimitive as _, ootr_utils::spoiler::HashIcon, std::{
         any::TypeId,
-        collections::HashMap,
+        collections::{HashMap, VecDeque},
         hash::Hash as _,
         io::prelude::*,
         num::NonZeroU8,
         pin::Pin,
         sync::Arc,
-        time::Duration
-    },
-    tokio::{
+        time::{
+            Duration,
+            Instant,
+        },
+    }, tokio::{
         select,
         sync::{
             Mutex,
@@ -61,7 +49,7 @@ use {
             sleep,
             timeout
         }
-    },
+    }
 };
 #[cfg(unix)] use std::ffi::OsString;
 
@@ -119,6 +107,7 @@ pub(crate) struct Subscription {
 #[derive(Debug, Clone)]
 pub(crate) enum InGameState {
     NotKnown,
+    Desynced,
     FileSelect,
     InGame {
         internal_count: u16,
@@ -134,6 +123,8 @@ pub(crate) struct InGameStruct {
     ingame_state: InGameState,
     filename: Option<Filename>,
     player_data: HashMap<NonZeroU8, (Filename, u32)>,
+    message_queue: VecDeque<(USBDataType, Vec<u8>)>,
+    pending_message: Option<Instant>,
 } 
 
 #[derive(Debug, Clone)]
@@ -187,7 +178,23 @@ async fn n64_recv() -> Result<(n64flashcart::Header, Vec<u8>), DeviceError> {
             Ok(_) => {
                 sleep(Duration::from_millis(1)).await;
             }
-            Err(e) => return Err(e),
+            Err(e) => {
+                // Purge read buffer to hopefully prevent errors on future reads
+                match e {
+                    DeviceError::READFAIL |
+                    DeviceError::BADHEADER |
+                    DeviceError::BADPADDING |
+                    DeviceError::BADPACKSIZE |
+                    DeviceError::_64D_BADCMP |
+                    DeviceError::_64D_BADDMA |
+                    DeviceError::SC64_COMMFAIL => {
+                        spawn_blocking(|| n64flashcart::purge()).await.expect("flashcart purge panic");
+                        n64_send(USBDataType::UNRECOVERABLE, vec![0u8; 16]).await?;
+                    }
+                    _ => {}
+                }
+                return Err(e);
+            }
         };
     }
 }
@@ -203,9 +210,7 @@ async fn n64_send(datatype: USBDataType, msg: Vec<u8>) -> Result<(), DeviceError
 }
 
 async fn send_handshake() {
-    let msg = "cmdt".as_bytes().to_vec();
-
-    let _ = n64_send(USBDataType::HANDSHAKE, msg).await;
+    let _ = n64_send(USBDataType::HANDSHAKE, "cmdt".as_bytes().to_vec()).await;
 }
 
 async fn send_handshake_response() -> Result<(), DeviceError> {
@@ -218,45 +223,44 @@ async fn send_handshake_response() -> Result<(), DeviceError> {
 }
 
 async fn send_reset() {
-    let msg = "cmdt".as_bytes().to_vec();
-
-    let _ = n64_send(USBDataType::RESET, msg).await;
+    let _ = n64_send(USBDataType::RESET, vec![0u8, 16]).await;
 }
 
-async fn send_player_data(world: NonZeroU8, name: Filename, progressive_items: u32) -> Result<(), DeviceError> {
+async fn send_ack() {
+    let _ = n64_send(USBDataType::ACK_MESSAGE, vec![0u8, 16]).await;
+}
+
+async fn send_err() {
+    let _ = n64_send(USBDataType::UNRECOVERABLE, vec![0u8, 16]).await;
+}
+
+async fn send_player_data(world: NonZeroU8, name: Filename, progressive_items: u32) -> (USBDataType, Vec<u8>) {
     let mut buf = [0; 16];
 
     buf[0] = world.get();
     *array_mut_ref![buf, 1, 8] = name.0;
     *array_mut_ref![buf, 9, 4] = progressive_items.to_be_bytes();
-
-    n64_send(USBDataType::PLAYER_NAMES, Vec::from(buf)).await
+    
+    return (USBDataType::PLAYER_NAMES, Vec::from(buf));
 }
 
-async fn get_item(queue: &[u16], internal_count: &mut u16) -> Result<bool, DeviceError> {
+async fn get_item(queue: &[u16], internal_count: &u16, messages: &mut VecDeque<(USBDataType, Vec<u8>)>) -> bool {
     if let Some(item) = queue.get(usize::from(*internal_count)) {
-        match send_item(*item).await {
-            Ok(_) => {
-                *internal_count += 1;
-                Ok(true)
-            },
-            Err(_) => {
-                Ok(false)
-            }
-        }
+        messages.push_back(send_item(*item).await);
+        return true;
     } else {
-        Ok(false)
+        return false;
     }
 }
 
-async fn send_item(item: u16) -> Result<(), DeviceError> {
+async fn send_item(item: u16) -> (USBDataType, Vec<u8>) {
     let mut msg: Vec<u8> = Vec::new();
 
     let [b1, b2] = item.to_be_bytes();
     msg.push(b1);
     msg.push(b2);
 
-    n64_send(USBDataType::SEND_ITEM, msg).await
+    return (USBDataType::SEND_ITEM, msg);
 }
 
 async fn process_n64_packet(header: n64flashcart::Header, data: Vec<u8>, struc: &mut InGameStruct) -> Result<(Option<InGameState>, Option<Vec<Message>>), DeviceError>
@@ -287,8 +291,10 @@ async fn process_n64_packet(header: n64flashcart::Header, data: Vec<u8>, struc: 
                 let filename = Filename(*array_ref![data_slice, 0, 8]);
                 struc.filename = Some(filename);
 
+                send_ack().await;
                 Ok((Some(InGameState::FileSelect), Some(vec![Message::Plugin(Box::new(ClientMessage::PlayerName(filename)))])))
             } else {
+                send_err().await;
                 Ok((None, None))
             }
         },
@@ -302,19 +308,22 @@ async fn process_n64_packet(header: n64flashcart::Header, data: Vec<u8>, struc: 
                     struc.filename = Some(filename);
                     messages.push(Message::Plugin(Box::new(ClientMessage::PlayerName(filename))));
                 }
-                let mut internal_count = u16::from_be_bytes(*array_ref![savedata, 0x90, 2]);
+                let internal_count = u16::from_be_bytes(*array_ref![savedata, 0x90, 2]);
 
                 messages.push(Message::Plugin(Box::new(ClientMessage::SaveData(savedata))));
                 let item_pending = if let InGameState::InGame { item_pending, .. } = struc.ingame_state {
                     item_pending
                 } else {
                     for (world, (name, progressive_items)) in struc.player_data.clone() {
-                        let _ = send_player_data(world, name, progressive_items).await;
+                        struc.message_queue.push_back(send_player_data(world, name, progressive_items).await);
                     }
-                    get_item(&struc.item_queue, &mut internal_count).await?
+                    get_item(&struc.item_queue, &internal_count, &mut struc.message_queue).await
                 };
+
+                send_ack().await;
                 Ok((Some(InGameState::InGame { internal_count, item_pending }), Some(messages)))
             } else {
+                send_err().await;
                 Ok((Some(InGameState::NotKnown), None))
             }
         },
@@ -334,19 +343,52 @@ async fn process_n64_packet(header: n64flashcart::Header, data: Vec<u8>, struc: 
                     target_world: target_world,
                 }));
 
+                send_ack().await;
                 Ok((None, Some(vec![message])))
             } else {
+                send_err().await;
                 Ok((None, None))
             }
         },
 
-        USBDataType::ACK_ITEM => {
-            if let InGameState::InGame { ref mut internal_count, ref mut item_pending } = struc.ingame_state {
-                if !get_item(&struc.item_queue, internal_count).await? {
-                    *item_pending = false;
+        USBDataType::ACK_MESSAGE => {
+            let InGameStruct {
+                ref mut ingame_state,
+                ref mut message_queue,
+                ref mut pending_message,
+                ..
+            } = *struc;
+            // Check if we actually sent a message to acknowledge.
+            if let None = pending_message {
+                Ok((Some(InGameState::Desynced), None))
+            } else {
+                if let Some((datatype, _)) = message_queue.pop_front() {
+                    match datatype {
+                        USBDataType::SEND_ITEM => {
+                            if let InGameState::InGame { ref mut internal_count, ref mut item_pending } = ingame_state {
+                                *internal_count += 1;
+                                if !get_item(&struc.item_queue, internal_count, message_queue).await {
+                                    *item_pending = false;
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                    *pending_message = None;
                 }
+                Ok((None, None))
             }
-            Ok((None, None))
+        },
+
+        USBDataType::UNRECOVERABLE => {
+            // Check if we actually sent a message to acknowledge.
+            if let None = struc.pending_message {
+                Ok((Some(InGameState::Desynced), None))
+            } else {
+                // Retry sending message, don't remove from queue yet
+                struc.pending_message = None;
+                Ok((None, None))
+            }
         },
 
         USBDataType::DUNGEON_REWARDS => {
@@ -383,13 +425,39 @@ async fn process_n64_packet(header: n64flashcart::Header, data: Vec<u8>, struc: 
                     shadow: if let (Some(world), Some(area)) = (NonZeroU8::new(shadow_world), OptHintArea::from_u8(shadow_area).and_then(|area| HintArea::try_from(area).ok())) { Some((world, area)) } else { None },
                     spirit: if let (Some(world), Some(area)) = (NonZeroU8::new(spirit_world), OptHintArea::from_u8(spirit_area).and_then(|area| HintArea::try_from(area).ok())) { Some((world, area)) } else { None },
                 }))];
+
+                send_ack().await;
                 Ok((None, Some(message)))
             } else {
+                send_err().await;
                 Ok((None, None))
             }
         }
 
         USBDataType::HEARTBEAT => Ok((None, None)),
+
+        USBDataType::RAWBINARY => {
+            // Read arbitrary memory from console.
+            // Currently unused, but skeleton kept to
+            // keep message queue moving if added later.
+
+            let InGameStruct {
+                ref mut message_queue,
+                ref mut pending_message,
+                ..
+            } = *struc;
+            // Check if we actually sent a message to acknowledge.
+            if let None = pending_message {
+                Ok((Some(InGameState::Desynced), None))
+            } else {
+                if let Some(_) = message_queue.pop_front() {
+                    // Handle raw byte message here
+                    *pending_message = None;
+                }
+                send_ack().await;
+                Ok((None, None))
+            }
+        }
 
         _ => {
             Err(DeviceError::SC64_FIRMWAREUNSUPPORTED)
@@ -502,7 +570,9 @@ async fn read(comm_state: &CommState) -> Result<(Option<CommState>, Vec<Message>
                                     item_queue: Vec::default(),
                                     ingame_state: InGameState::NotKnown,
                                     filename: None,
-                                    player_data: HashMap::default()
+                                    player_data: HashMap::default(),
+                                    message_queue: VecDeque::default(),
+                                    pending_message: None,
                                 };
 
                                 Some(CommState::Ready(Arc::new(Mutex::new(struc))))
@@ -530,6 +600,30 @@ async fn read(comm_state: &CommState) -> Result<(Option<CommState>, Vec<Message>
 
             dbg_println!("InGameState: {:?}", struc.ingame_state);
 
+            // Handle potentially lost acknowledge packet without
+            // total communications loss. Force reset the connection
+            // to avoid duplicating items and desyncing the item counter.
+            // 5 seconds is approximately the time between heartbeats,
+            // with 10 seconds as the normal timeout. 7 seconds is checked
+            // here as the ack should not take longer than a full heartbeat
+            // cycle to be sent, accounting for some generous console lag.
+            // Timeout starts after the message is sent to minimize lag.
+            if let Some(message_timeout) = struc.pending_message {
+                if message_timeout.elapsed().as_secs_f32() > 7.0 {
+                    dbg_println!("N64 did not acknowledge message, resetting");
+                    return Ok((Some(CommState::Disconnect), messages));
+                }
+            }
+
+            if let None = struc.pending_message {
+                if let Some((datatype, msg)) = struc.message_queue.front() {
+                    match n64_send(*datatype, msg.clone()).await {
+                        Ok(_) => struc.pending_message = Some(Instant::now()),
+                        Err(_) => struc.pending_message = None,
+                    }
+                }
+            }
+
             select! {
                 read_or_timeout = timeout(Duration::from_secs(10), n64_recv()) => {
                     match read_or_timeout {
@@ -544,6 +638,8 @@ async fn read(comm_state: &CommState) -> Result<(Option<CommState>, Vec<Message>
                                             }
                                             if let Some(InGameState::NotKnown) = state_ {
                                                 Some(CommState::WaitForGame)
+                                            } else if let Some(InGameState::Desynced) = state_ {
+                                                Some(CommState::Disconnect)
                                             } else if let Some(value) = state_ {
                                                 struc.ingame_state = value;
                                                 None
@@ -583,10 +679,15 @@ async fn read(comm_state: &CommState) -> Result<(Option<CommState>, Vec<Message>
                     match msg {
                         ServerMessage::ItemQueue(items) => {
                             struc.item_queue = items;
-                            let item_queue = struc.item_queue.clone();
-                            if let InGameState::InGame { ref mut internal_count, ref mut item_pending } = struc.ingame_state {
+                            let InGameStruct {
+                                ref mut ingame_state,
+                                ref mut message_queue,
+                                ref item_queue,
+                                ..
+                            } = *struc;
+                            if let InGameState::InGame { ref internal_count, ref mut item_pending } = ingame_state {
                                 if !*item_pending {
-                                    if let Ok(true) = get_item(&item_queue, internal_count).await {
+                                    if let true = get_item(item_queue, internal_count, message_queue).await {
                                         *item_pending = true;
                                     }
                                 }
@@ -594,24 +695,39 @@ async fn read(comm_state: &CommState) -> Result<(Option<CommState>, Vec<Message>
                         },
                         ServerMessage::GetItem(item) => {
                             struc.item_queue.push(item);
-                            let item_queue = struc.item_queue.clone();
-                            if let InGameState::InGame { ref mut internal_count, ref mut item_pending } = struc.ingame_state {
+                            let InGameStruct {
+                                ref mut ingame_state,
+                                ref mut message_queue,
+                                ref item_queue,
+                                ..
+                            } = *struc;
+                            if let InGameState::InGame { ref internal_count, ref mut item_pending } = ingame_state {
                                 if !*item_pending {
-                                    if let Ok(true) = get_item(&item_queue, internal_count).await {
+                                    if let true = get_item(item_queue, internal_count, message_queue).await {
                                         *item_pending = true;
                                     }
                                 }
                             }
                         },
                         ServerMessage::PlayerName(world, new_name) => {
-                            let (name, progressive_items) = struc.player_data.entry(world).or_default();
+                            let InGameStruct {
+                                ref mut message_queue,
+                                ref mut player_data,
+                                ..
+                            } = *struc;
+                            let (name, progressive_items) = player_data.entry(world).or_default();
                             *name = new_name;
-                            let _ = send_player_data(world, *name, *progressive_items).await;
+                            message_queue.push_back(send_player_data(world, *name, *progressive_items).await);
                         },
                         ServerMessage::ProgressiveItems(world, new_progressive_items) => {
-                            let (name, progressive_items) = struc.player_data.entry(world).or_default();
+                            let InGameStruct {
+                                ref mut message_queue,
+                                ref mut player_data,
+                                ..
+                            } = *struc;
+                            let (name, progressive_items) = player_data.entry(world).or_default();
                             *progressive_items = new_progressive_items;
-                            let _ = send_player_data(world, *name, *progressive_items).await;
+                            message_queue.push_back(send_player_data(world, *name, *progressive_items).await);
                         },
                     }
                     None

--- a/crate/multiworld-gui/src/flashcart.rs
+++ b/crate/multiworld-gui/src/flashcart.rs
@@ -13,10 +13,10 @@ use {
             Stream,
             StreamExt as _,
         },
-    }, iced::advanced::subscription::{
+    }, iced::{advanced::subscription::{
         EventStream,
         Recipe,
-    }, log_lock::lock, multiworld::{
+    }}, log_lock::lock, multiworld::{
         Filename, HintArea, OptHintArea, frontend::{
             ClientMessage,
             ServerMessage
@@ -366,7 +366,6 @@ async fn process_n64_packet(header: n64flashcart::Header, data: Vec<u8>, struc: 
 
         USBDataType::ACK_MESSAGE => {
             let InGameStruct {
-                ref mut ingame_state,
                 ref mut message_queue,
                 ref mut pending_message,
                 ..
@@ -375,23 +374,33 @@ async fn process_n64_packet(header: n64flashcart::Header, data: Vec<u8>, struc: 
             if let None = pending_message {
                 Ok((Some(InGameState::Desynced), None))
             } else {
-                if let Some((datatype, _)) = message_queue.pop_front() {
-                    match datatype {
-                        USBDataType::SEND_ITEM => {
-                            if let InGameState::InGame { ref mut internal_count, ref mut item_pending } = ingame_state {
-                                *internal_count += 1;
-                                if !get_item(&struc.item_queue, internal_count, message_queue).await {
-                                    *item_pending = false;
-                                }
-                            }
-                        }
-                        _ => {}
-                    }
-                    *pending_message = None;
-                }
+                let _ = message_queue.pop_front();
+                *pending_message = None;
                 Ok((None, None))
             }
         },
+
+        USBDataType::ITEM_GIVEN => {
+            let InGameStruct {
+                ref mut ingame_state,
+                ref mut message_queue,
+                ..
+            } = *struc;
+            if let InGameState::InGame { ref mut internal_count, ref mut item_pending } = ingame_state {
+                if !*item_pending {
+                    Ok((Some(InGameState::Desynced), None))
+                } else {
+                    send_ack().await;
+                    *internal_count += 1;
+                    if !get_item(&struc.item_queue, internal_count, message_queue).await {
+                        *item_pending = false;
+                    }
+                    Ok((None, None))
+                }
+            } else {
+                Err(DeviceError::READFAIL)
+            }
+        }
 
         USBDataType::UNRECOVERABLE => {
             // Check if we actually sent a message to acknowledge.

--- a/crate/multiworld-gui/src/flashcart.rs
+++ b/crate/multiworld-gui/src/flashcart.rs
@@ -55,11 +55,19 @@ use {
 
 const DEBUG_LOGGING: bool = true;
 
+macro_rules! log_println {
+    ($enable_log:expr, $($arg:tt)*) => {
+        if $enable_log {
+            let timestamp = Utc::now().format("%Y-%m-%d %H:%M:%S");
+            println!("[{timestamp}] {}", format_args!($($arg)*));
+            let _ = lock!(log = crate::LOG; writeln!(&*log, "[{timestamp}] {}", format_args!($($arg)*)));
+        }
+    };
+}
+
 macro_rules! dbg_println {
     ($($arg:tt)*) => {
-        if DEBUG_LOGGING {
-            println!($($arg)*);
-        }
+        log_println!(DEBUG_LOGGING, $($arg)*)
     };
 }
 
@@ -774,9 +782,7 @@ impl Recipe for Subscription {
                     Some(FlashcartState::SEARCHING(FlashcartCache { player_data: HashMap::default() }))
                 },
                 FlashcartState::DISCONNECTED(cache) => {
-                    if log {
-                        let _ = lock!(log = crate::LOG; writeln!(&*log, "{} Flashcart: waiting 5 seconds before next scan", Utc::now().format("%Y-%m-%d %H:%M:%S")));
-                    }
+                    log_println!(log, "Flashcart: waiting 5 seconds before next scan");
                     let _ = sleep(Duration::from_secs(5)).await;
                     Some(FlashcartState::SEARCHING(cache.to_owned()))
                 },
@@ -863,8 +869,8 @@ impl Recipe for Subscription {
             }
 
             Ok::<_, ConnectError>(Some((stream::iter(messages).map(Ok::<_, ConnectError>), new_state.unwrap_or(state))))
-        }}).try_flatten().map(|res| {
-            let mut print_debug = true;
+        }}).try_flatten().then(|res| async move {
+            let mut print_debug = DEBUG_LOGGING;
 
             if let Ok(message) = &res {
                 if let Message::Plugin(plugin) = message {

--- a/crate/multiworld-gui/src/flashcart.rs
+++ b/crate/multiworld-gui/src/flashcart.rs
@@ -253,7 +253,9 @@ async fn process_n64_packet(header: n64flashcart::Header, data: Vec<u8>, struc: 
         // Summercart menu responses are UNFloader-compatible.
         // Everdrive gets filtered out by n64flashcart.
         USBDataType::TEXT => {
-            if let Ok(text) = TryInto::<[u8 ; 6]>::try_into(data) {
+            if data.len() >= 6 {
+                let data_slice = data.into_boxed_slice();
+                let text = *array_ref![data_slice, 0, 6];
                 match text {
                     [b'j', b'o', b'y', b'b', b'u', b's'] => Ok((Some(InGameState::NotKnown), None)),
                     _ => Err(DeviceError::SC64_FIRMWAREUNSUPPORTED),

--- a/crate/multiworld-gui/src/flashcart.rs
+++ b/crate/multiworld-gui/src/flashcart.rs
@@ -390,7 +390,7 @@ async fn process_n64_packet(header: n64flashcart::Header, data: Vec<u8>, struc: 
                 if !*item_pending {
                     Ok((Some(InGameState::Desynced), None))
                 } else {
-                    //send_ack().await;
+                    send_ack().await;
                     *internal_count += 1;
                     if !get_item(&struc.item_queue, internal_count, message_queue).await {
                         *item_pending = false;

--- a/crate/multiworld-gui/src/flashcart.rs
+++ b/crate/multiworld-gui/src/flashcart.rs
@@ -128,6 +128,11 @@ pub(crate) struct InGameStruct {
 } 
 
 #[derive(Debug, Clone)]
+pub(crate) struct FlashcartCache {
+    player_data: HashMap<NonZeroU8, (Filename, u32)>,
+}
+
+#[derive(Debug, Clone)]
 pub(crate) enum CommState {
     Disconnect,
     SendHandshake,
@@ -139,10 +144,10 @@ pub(crate) enum CommState {
 #[derive(Debug, Clone)]
 pub enum FlashcartState {
     INITIALIZE,
-    DISCONNECTED,
-    SEARCHING,
-    OPENING(String),
-    CONNECTED(String, CommState, Arc<FlashcartGuard>)
+    DISCONNECTED(FlashcartCache),
+    SEARCHING(FlashcartCache),
+    OPENING(String, FlashcartCache),
+    CONNECTED(String, CommState, FlashcartCache, Arc<FlashcartGuard>)
 }
 
 #[derive(Debug)]
@@ -510,7 +515,7 @@ async fn process_handshake(header: n64flashcart::Header, data: Vec<u8>) -> Resul
     }
 }
 
-async fn read(comm_state: &CommState) -> Result<(Option<CommState>, Vec<Message>), DeviceError> {
+async fn read(comm_state: &CommState, cache: &FlashcartCache) -> Result<(Option<CommState>, Vec<Message>), DeviceError> {
     let mut messages = Vec::new();
     let next_state = match comm_state {
         CommState::Disconnect => Some(CommState::Disconnect),
@@ -570,7 +575,7 @@ async fn read(comm_state: &CommState) -> Result<(Option<CommState>, Vec<Message>
                                     item_queue: Vec::default(),
                                     ingame_state: InGameState::NotKnown,
                                     filename: None,
-                                    player_data: HashMap::default(),
+                                    player_data: cache.player_data.clone(),
                                     message_queue: VecDeque::default(),
                                     pending_message: None,
                                 };
@@ -766,33 +771,33 @@ impl Recipe for Subscription {
                 FlashcartState::INITIALIZE => {
                     n64flashcart::initialize();
                     n64flashcart::set_protocol(ProtocolVer::VERSION2);
-                    Some(FlashcartState::SEARCHING)
+                    Some(FlashcartState::SEARCHING(FlashcartCache { player_data: HashMap::default() }))
                 },
-                FlashcartState::DISCONNECTED => {
+                FlashcartState::DISCONNECTED(cache) => {
                     if log {
                         let _ = lock!(log = crate::LOG; writeln!(&*log, "{} Flashcart: waiting 5 seconds before next scan", Utc::now().format("%Y-%m-%d %H:%M:%S")));
                     }
                     let _ = sleep(Duration::from_secs(5)).await;
-                    Some(FlashcartState::SEARCHING)
+                    Some(FlashcartState::SEARCHING(cache.to_owned()))
                 },
-                FlashcartState::SEARCHING => {
+                FlashcartState::SEARCHING(cache) => {
                     if let Some(attached_device) = device {
                         let status = n64flashcart::connect(attached_device.vid, attached_device.pid, &attached_device.serial);
                         if status == DeviceError::CARTFINDFAIL {
                             n64flashcart::initialize();
                             n64flashcart::set_protocol(ProtocolVer::VERSION2);
-                            Some(FlashcartState::DISCONNECTED)
+                            Some(FlashcartState::DISCONNECTED(cache.to_owned()))
                         } else if status != DeviceError::OK {
-                            Some(FlashcartState::DISCONNECTED)
+                            Some(FlashcartState::DISCONNECTED(cache.to_owned()))
                         } else {
                             let cart_name = n64flashcart::cart_type_to_str(n64flashcart::get_cart());
-                            Some(FlashcartState::OPENING(cart_name.to_string()))
+                            Some(FlashcartState::OPENING(cart_name.to_string(), cache.to_owned()))
                         }
                     } else {
                         None
                     }
                 },
-                FlashcartState::OPENING(name) => {
+                FlashcartState::OPENING(name, cache) => {
                     if let Some(_) = device {
                         let status = n64flashcart::open();
                         if status != DeviceError::OK {
@@ -800,33 +805,55 @@ impl Recipe for Subscription {
                             if status == DeviceError::CANTOPEN {
                                 messages.push(Message::FlashcartLocked);
                             }
-                            Some(FlashcartState::DISCONNECTED)
+                            Some(FlashcartState::DISCONNECTED(cache.to_owned()))
                         } else {
                             dbg_println!("Flashcart USB connection opened");
-                            Some(FlashcartState::CONNECTED(name.to_owned(), CommState::WaitForGame, Arc::new(FlashcartGuard)))
+                            Some(FlashcartState::CONNECTED(name.to_owned(), CommState::WaitForGame, cache.to_owned(), Arc::new(FlashcartGuard)))
                         }
                     } else {
-                        Some(FlashcartState::SEARCHING)
+                        Some(FlashcartState::SEARCHING(cache.to_owned()))
                     }
                 },
-                FlashcartState::CONNECTED(name, comm_state, guard) => {
+                FlashcartState::CONNECTED(name, comm_state, cache, guard) => {
                     if let Some(_) = device {
-                        match read(comm_state).await {
+                        match read(comm_state, cache).await {
                             Ok((next_state, m)) => {
                                 messages.extend(m);
-                                match next_state {
-                                    Some(CommState::Disconnect) => Some(FlashcartState::DISCONNECTED),
-                                    Some(new_state) => Some(FlashcartState::CONNECTED(name.to_owned(), new_state, guard.to_owned())),
-                                    None => None,
+                                match comm_state {
+                                    CommState::Ready(_struc) => {
+                                        match next_state {
+                                            Some(ready_state @ CommState::Ready(_)) => Some(FlashcartState::CONNECTED(name.to_owned(), ready_state, cache.to_owned(), guard.to_owned())),
+                                            Some(CommState::Disconnect) => {
+                                                let struc = _struc.lock().await;
+                                                let mut new_cache = cache.to_owned();
+                                                new_cache.player_data = struc.player_data.clone();
+                                                Some(FlashcartState::DISCONNECTED(new_cache))
+                                            },
+                                            Some(new_state) => {
+                                                let struc = _struc.lock().await;
+                                                let mut new_cache = cache.to_owned();
+                                                new_cache.player_data = struc.player_data.clone();
+                                                Some(FlashcartState::CONNECTED(name.to_owned(), new_state, new_cache, guard.to_owned()))
+                                            },
+                                            None => None,
+                                        }
+                                    },
+                                    _ => {
+                                        match next_state {
+                                            Some(CommState::Disconnect) => Some(FlashcartState::DISCONNECTED(cache.to_owned())),
+                                            Some(new_state) => Some(FlashcartState::CONNECTED(name.to_owned(), new_state, cache.to_owned(), guard.to_owned())),
+                                            None => None,
+                                        }
+                                    }
                                 }
                             },
                             Err(e) => {
                                 messages.push(Message::FlashcartCommError(Arc::new(vec![ConnectError::DeviceError(e)])));
-                                Some(FlashcartState::CONNECTED(name.to_owned(), comm_state.to_owned(), guard.to_owned()))
+                                Some(FlashcartState::CONNECTED(name.to_owned(), comm_state.to_owned(), cache.to_owned(), guard.to_owned()))
                             }
                         }
                     } else {
-                        Some(FlashcartState::SEARCHING)
+                        Some(FlashcartState::SEARCHING(cache.to_owned()))
                     }
                 }
             };

--- a/crate/multiworld-gui/src/flashcart.rs
+++ b/crate/multiworld-gui/src/flashcart.rs
@@ -681,6 +681,9 @@ impl Recipe for Subscription {
                         let status = n64flashcart::open();
                         if status != DeviceError::OK {
                             dbg_println!("Failed to open USB connection to flashcart, retrying, error code {}", status.value());
+                            if status == DeviceError::CANTOPEN {
+                                messages.push(Message::FlashcartLocked);
+                            }
                             Some(FlashcartState::DISCONNECTED)
                         } else {
                             dbg_println!("Flashcart USB connection opened");

--- a/crate/multiworld-gui/src/flashcart.rs
+++ b/crate/multiworld-gui/src/flashcart.rs
@@ -390,7 +390,7 @@ async fn process_n64_packet(header: n64flashcart::Header, data: Vec<u8>, struc: 
                 if !*item_pending {
                     Ok((Some(InGameState::Desynced), None))
                 } else {
-                    send_ack().await;
+                    //send_ack().await;
                     *internal_count += 1;
                     if !get_item(&struc.item_queue, internal_count, message_queue).await {
                         *item_pending = false;

--- a/crate/multiworld-gui/src/flashcart.rs
+++ b/crate/multiworld-gui/src/flashcart.rs
@@ -1,7 +1,8 @@
 use {
     crate::{
         FrontendWriter,
-        Message
+        Message,
+        UsbSerialPort,
     },
     arrayref::{
         array_mut_ref,
@@ -56,6 +57,7 @@ use {
             Mutex,
             mpsc
         },
+        task::spawn_blocking,
         time::{
             sleep,
             timeout
@@ -97,8 +99,6 @@ pub(crate) enum ConnectError {
     UnknownReplyLength(usize),
     #[error("failed to reply to handshake")]
     FailedReply,
-    #[error("no reply from the console")]
-    NoMessage,
     #[error("unhandled device error: {0:x?}")]
     DeviceError(DeviceError),
     #[error("received unknown message {0} from flashcart")]
@@ -114,6 +114,7 @@ impl From<OsString> for ConnectError {
 
 pub(crate) struct Subscription {
     pub(crate) log: bool,
+    pub(crate) device: Option<UsbSerialPort>,
 }
 
 #[derive(Debug, Clone)]
@@ -138,6 +139,7 @@ pub(crate) struct InGameStruct {
 
 #[derive(Debug, Clone)]
 pub(crate) enum CommState {
+    Disconnect,
     SendHandshake,
     WaitForGame,
     Handshake,
@@ -146,10 +148,22 @@ pub(crate) enum CommState {
 
 #[derive(Debug, Clone)]
 pub enum FlashcartState {
+    INITIALIZE,
     DISCONNECTED,
     SEARCHING,
     OPENING(String),
-    CONNECTED(String, CommState)
+    CONNECTED(String, CommState, Arc<FlashcartGuard>)
+}
+
+#[derive(Debug)]
+pub struct FlashcartGuard;
+
+impl Drop for FlashcartGuard {
+    fn drop(&mut self) {
+        if n64flashcart::isopen() {
+            n64flashcart::close();
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -161,60 +175,62 @@ struct HandshakeResponse {
 
 async fn n64_recv() -> Result<(n64flashcart::Header, Vec<u8>), DeviceError> {
     loop {
-        match n64flashcart::read() {
-            Ok((header, data)) => {
-                if header.datatype != USBDataType::EMPTY {
-                    return Ok((header, data));
-                }
+        let res = spawn_blocking(|| n64flashcart::read()).await.expect("flashcart read panic");
+        match res {
+            Ok((header, data)) if header.datatype != USBDataType::EMPTY => {
+                return Ok((header, data));
+            }
+            Ok(_) => {
+                sleep(Duration::from_millis(1)).await;
             }
             Err(e) => return Err(e),
         };
     }
 }
 
-fn n64_send(datatype: USBDataType, msg: Vec<u8>) -> Result<(), DeviceError> {
+async fn n64_send(datatype: USBDataType, msg: Vec<u8>) -> Result<(), DeviceError> {
     let header = n64flashcart::Header { datatype: datatype, length: msg.len() };
-    let status = n64flashcart::write(header, msg);
+    let status = spawn_blocking(|| n64flashcart::write(header, msg)).await.expect("flashcart send panic");
     match status {
         DeviceError::OK => Ok(()),
         _ => Err(status)
     }
 }
 
-fn send_handshake() {
+async fn send_handshake() {
     let msg = "cmdt".as_bytes().to_vec();
 
-    let _ = n64_send(USBDataType::HANDSHAKE, msg);
+    let _ = n64_send(USBDataType::HANDSHAKE, msg).await;
 }
 
-fn send_handshake_response() -> Result<(), DeviceError> {
+async fn send_handshake_response() -> Result<(), DeviceError> {
     let mut msg = "MW".as_bytes().to_vec();
     msg.push(PROTOCOL_VERSION);
     msg.push(MW_SEND_OWN_ITEMS);
     msg.push(MW_PROGRESSIVE_ITEMS_ENABLE);
 
-    n64_send(USBDataType::HANDSHAKE, msg)
+    n64_send(USBDataType::HANDSHAKE, msg).await
 }
 
-fn send_reset() {
+async fn send_reset() {
     let msg = "cmdt".as_bytes().to_vec();
 
-    let _ = n64_send(USBDataType::RESET, msg);
+    let _ = n64_send(USBDataType::RESET, msg).await;
 }
 
-fn send_player_data(world: NonZeroU8, name: Filename, progressive_items: u32) -> Result<(), DeviceError> {
+async fn send_player_data(world: NonZeroU8, name: Filename, progressive_items: u32) -> Result<(), DeviceError> {
     let mut buf = [0; 16];
 
     buf[0] = world.get();
     *array_mut_ref![buf, 1, 8] = name.0;
     *array_mut_ref![buf, 9, 4] = progressive_items.to_be_bytes();
 
-    n64_send(USBDataType::PLAYER_NAMES, Vec::from(buf))
+    n64_send(USBDataType::PLAYER_NAMES, Vec::from(buf)).await
 }
 
 async fn get_item(queue: &[u16], internal_count: &mut u16) -> Result<bool, DeviceError> {
     if let Some(item) = queue.get(usize::from(*internal_count)) {
-        match send_item(*item) {
+        match send_item(*item).await {
             Ok(_) => {
                 *internal_count += 1;
                 Ok(true)
@@ -228,14 +244,14 @@ async fn get_item(queue: &[u16], internal_count: &mut u16) -> Result<bool, Devic
     }
 }
 
-fn send_item(item: u16) -> Result<(), DeviceError> {
+async fn send_item(item: u16) -> Result<(), DeviceError> {
     let mut msg: Vec<u8> = Vec::new();
 
     let [b1, b2] = item.to_be_bytes();
     msg.push(b1);
     msg.push(b2);
 
-    n64_send(USBDataType::SEND_ITEM, msg)
+    n64_send(USBDataType::SEND_ITEM, msg).await
 }
 
 async fn process_n64_packet(header: n64flashcart::Header, data: Vec<u8>, struc: &mut InGameStruct) -> Result<(Option<InGameState>, Option<Vec<Message>>), DeviceError>
@@ -374,7 +390,6 @@ async fn process_n64_packet(header: n64flashcart::Header, data: Vec<u8>, struc: 
         }
 
         USBDataType::HEARTBEAT => Ok((None, None)),
-        USBDataType::EMPTY => Ok((None, None)),
 
         _ => {
             Err(DeviceError::SC64_FIRMWAREUNSUPPORTED)
@@ -382,10 +397,7 @@ async fn process_n64_packet(header: n64flashcart::Header, data: Vec<u8>, struc: 
     }
 }
 
-fn process_handshake(header: n64flashcart::Header, data: Vec<u8>) -> Result<HandshakeResponse, ConnectError> {
-    if header.datatype == USBDataType::EMPTY {
-        return Err(ConnectError::NoMessage);
-    }
+async fn process_handshake(header: n64flashcart::Header, data: Vec<u8>) -> Result<HandshakeResponse, ConnectError> {
     if header.datatype != USBDataType::HANDSHAKE {
         return Err(ConnectError::UnknownReplyHeader(header.datatype));
     }
@@ -395,7 +407,7 @@ fn process_handshake(header: n64flashcart::Header, data: Vec<u8>) -> Result<Hand
             match value {
                 [b'O', b'o', b'T', b'R', PROTOCOL_VERSION, major, minor, patch, branch, supplementary, player_id, hash1, hash2, hash3, hash4, hash5] => {
                     dbg_println!("Handshake reply received. Repeating protocol version to finalize handshake");
-                    match send_handshake_response() {
+                    match send_handshake_response().await {
                         Ok(_) => {
                             dbg_println!("Protocol version sent");
 
@@ -430,79 +442,86 @@ fn process_handshake(header: n64flashcart::Header, data: Vec<u8>) -> Result<Hand
     }
 }
 
-async fn read(name: &String, comm_state: &CommState) -> Result<(Option<FlashcartState>, Vec<Message>), DeviceError> {
+async fn read(comm_state: &CommState) -> Result<(Option<CommState>, Vec<Message>), DeviceError> {
     let mut messages = Vec::new();
     let next_state = match comm_state {
+        CommState::Disconnect => Some(CommState::Disconnect),
         CommState::WaitForGame => {
-            match n64flashcart::read() {
-                Ok((header, _data)) => {
-                    match header.datatype {
-                        USBDataType::HANDSHAKE | USBDataType::RESET => {
-                            Some(FlashcartState::CONNECTED(name.to_owned(), CommState::SendHandshake))
-                        },
-                        USBDataType::EMPTY => None,
-                        _ => {
-                            send_reset();
-                            None
+            match timeout(Duration::from_secs(10), n64_recv()).await {
+                Ok(read_result) => {
+                    match read_result {
+                        Ok((header, _data)) => {
+                            match header.datatype {
+                                USBDataType::HANDSHAKE | USBDataType::RESET => {
+                                    Some(CommState::SendHandshake)
+                                },
+                                _ => {
+                                    send_reset().await;
+                                    None
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            dbg_println!("Read error while waiting for handshake, {}", e.value());
+                            Some(CommState::Disconnect)
                         }
                     }
-                }
-                Err(e) => {
-                    dbg_println!("Read error while waiting for handshake, {}", e.value());
-                    Some(FlashcartState::DISCONNECTED)
+                },
+                Err(_) => {
+                    dbg_println!("No message from N64 in 10 seconds");
+                    Some(CommState::WaitForGame)
                 }
             }
         },
         CommState::SendHandshake => {
-            send_handshake();
-            Some(FlashcartState::CONNECTED(name.to_owned(), CommState::Handshake))
+            send_handshake().await;
+            Some(CommState::Handshake)
         },
         CommState::Handshake => {
-            match n64flashcart::read() {
-                Ok((header, data)) => {
-                    let mut response = None;
-                    let mut errors = Vec::default();
-                    match process_handshake(header, data) {
-                        Ok(resp) => {
-                            response = Some(resp);
-                        }
-                        Err(e) => {
-                            match e {
-                                ConnectError::NoMessage => {}
-                                _ => {
-                                    errors.push((name.to_owned(), e));
-                                }
+            match timeout(Duration::from_secs(10), n64_recv()).await {
+                Ok(read_result) => {
+                    match read_result {
+                        Ok((header, data)) => {
+                            let mut response = None;
+                            let mut errors = Vec::default();
+                            match process_handshake(header, data).await {
+                                Ok(resp) => response = Some(resp),
+                                Err(e) => errors.push(e),
+                            }
+                            if let Some(HandshakeResponse { version, player_id, file_hash }) = response {
+                                let (tx, rx) = mpsc::channel(1_024);
+
+                                messages.push(Message::FrontendConnected(FrontendWriter::Mpsc(tx)));
+                                messages.push(Message::Plugin(Box::new(ClientMessage::PlayerId(player_id))));
+                                messages.push(Message::Plugin(Box::new(ClientMessage::FileHash(Some(file_hash)))));
+                                messages.push(Message::FlashcartHandshakeSuccessful());
+
+                                let struc = InGameStruct {
+                                    _version: version,
+                                    rx: rx,
+                                    item_queue: Vec::default(),
+                                    ingame_state: InGameState::NotKnown,
+                                    filename: None,
+                                    player_data: HashMap::default()
+                                };
+
+                                Some(CommState::Ready(Arc::new(Mutex::new(struc))))
+                            } else if errors.is_empty() {
+                                None
+                            } else {
+                                messages.push(Message::FlashcartHandshakeFailed(Arc::new(errors)));
+                                Some(CommState::WaitForGame)
                             }
                         }
+                        Err(e) => {
+                            dbg_println!("Read error while finalizing for handshake, {}", e.value());
+                            Some(CommState::Disconnect)
+                        }
                     }
-                    if let Some(HandshakeResponse { version, player_id, file_hash }) = response {
-                        let (tx, rx) = mpsc::channel(1_024);
-
-                        messages.push(Message::FrontendConnected(FrontendWriter::Mpsc(tx)));
-                        messages.push(Message::Plugin(Box::new(ClientMessage::PlayerId(player_id))));
-                        messages.push(Message::Plugin(Box::new(ClientMessage::FileHash(Some(file_hash)))));
-                        messages.push(Message::FlashcartHandshakeSuccessful());
-
-                        let struc = InGameStruct {
-                            _version: version,
-                            rx: rx,
-                            item_queue: Vec::default(),
-                            ingame_state: InGameState::NotKnown,
-                            filename: None,
-                            player_data: HashMap::default()
-                        };
-
-                        Some(FlashcartState::CONNECTED(name.to_owned(), CommState::Ready(Arc::new(Mutex::new(struc)))))
-                    } else if errors.is_empty() {
-                        None
-                    } else {
-                        messages.push(Message::FlashcartHandshakeFailed(Arc::new(errors)));
-                        Some(FlashcartState::CONNECTED(name.to_owned(), CommState::WaitForGame))
-                    }
-                }
-                Err(e) => {
-                    dbg_println!("Read error while finalizing for handshake, {}", e.value());
-                    Some(FlashcartState::DISCONNECTED)
+                },
+                Err(_) => {
+                    dbg_println!("No message from N64 in 10 seconds");
+                    Some(CommState::Disconnect)
                 }
             }
         },
@@ -512,10 +531,10 @@ async fn read(name: &String, comm_state: &CommState) -> Result<(Option<Flashcart
             dbg_println!("InGameState: {:?}", struc.ingame_state);
 
             select! {
-                n64_or_timeout = timeout(Duration::from_secs(10), n64_recv()) => {
-                    match n64_or_timeout {
-                        Ok(n64_result) => {
-                            match n64_result {
+                read_or_timeout = timeout(Duration::from_secs(10), n64_recv()) => {
+                    match read_or_timeout {
+                        Ok(read_result) => {
+                            match read_result {
                                 Ok((header, data)) => {
                                     let datatype = header.datatype.value();
                                     match process_n64_packet(header, data, &mut struc).await {
@@ -524,7 +543,7 @@ async fn read(name: &String, comm_state: &CommState) -> Result<(Option<Flashcart
                                                 messages.extend(msg);
                                             }
                                             if let Some(InGameState::NotKnown) = state_ {
-                                                Some(FlashcartState::CONNECTED(name.to_owned(), CommState::WaitForGame))
+                                                Some(CommState::WaitForGame)
                                             } else if let Some(value) = state_ {
                                                 struc.ingame_state = value;
                                                 None
@@ -535,9 +554,9 @@ async fn read(name: &String, comm_state: &CommState) -> Result<(Option<Flashcart
                                         Err(e) => {
                                             let mut errors = Vec::default();
                                             if let DeviceError::SC64_FIRMWAREUNSUPPORTED = e {
-                                                errors.push((name.to_owned(), ConnectError::UnknownCommand(datatype)));
+                                                errors.push(ConnectError::UnknownCommand(datatype));
                                             } else {
-                                                errors.push((name.to_owned(), ConnectError::DeviceError(e)));
+                                                errors.push(ConnectError::DeviceError(e));
                                             }
                                             dbg_println!("Error processing data from N64, {:?}", e);
                                             messages.push(Message::FlashcartCommError(Arc::new(errors)));
@@ -547,15 +566,15 @@ async fn read(name: &String, comm_state: &CommState) -> Result<(Option<Flashcart
                                 },
                                 Err(e) => {
                                     dbg_println!("Error receiving from N64, {:?}", e);
-                                    let errors = vec![(name.to_owned(), ConnectError::DeviceError(e))];
+                                    let errors = vec![ConnectError::DeviceError(e)];
                                     messages.push(Message::FlashcartCommError(Arc::new(errors)));
-                                    Some(FlashcartState::DISCONNECTED)
+                                    Some(CommState::Disconnect)
                                 }
                             }
                         },
                         Err(_) => {
                             dbg_println!("No message from N64 in 10 seconds");
-                            Some(FlashcartState::DISCONNECTED)
+                            Some(CommState::Disconnect)
                         }
                     }
                 },
@@ -609,58 +628,86 @@ impl Recipe for Subscription {
 
     fn hash(&self, state: &mut iced::advanced::subscription::Hasher) {
         TypeId::of::<Self>().hash(state);
+
+        if let Some(device) = &self.device {
+            device.vid.hash(state);
+            device.pid.hash(state);
+            device.serial.hash(state); 
+        } else {
+            0.hash(state);
+        }
     }
 
     fn stream(self: Box<Self>, _: EventStream) -> Pin<Box<dyn Stream<Item = Message> + Send>> {
         let log = self.log || DEBUG_LOGGING;
-        stream::try_unfold(FlashcartState::SEARCHING, move |state| async move {
+        stream::try_unfold(FlashcartState::INITIALIZE, move |state| {
+            let device = self.device.clone();
+            async move {
             let _ = sleep(Duration::from_millis(1)).await;
             let mut messages: Vec<Message> = Vec::new();
 
             let new_state = match &state {
+                FlashcartState::INITIALIZE => {
+                    n64flashcart::initialize();
+                    n64flashcart::set_protocol(ProtocolVer::VERSION2);
+                    Some(FlashcartState::SEARCHING)
+                },
                 FlashcartState::DISCONNECTED => {
                     if log {
-                        let _ = lock!(log = crate::LOG; writeln!(&*log, "{} EverDrive: waiting 5 seconds before next scan", Utc::now().format("%Y-%m-%d %H:%M:%S")));
-                    }
-                    if n64flashcart::isopen() {
-                        n64flashcart::close();
+                        let _ = lock!(log = crate::LOG; writeln!(&*log, "{} Flashcart: waiting 5 seconds before next scan", Utc::now().format("%Y-%m-%d %H:%M:%S")));
                     }
                     let _ = sleep(Duration::from_secs(5)).await;
                     Some(FlashcartState::SEARCHING)
                 },
                 FlashcartState::SEARCHING => {
-                    let status = n64flashcart::find();
-                    if status == DeviceError::CARTFINDFAIL {
-                        n64flashcart::initialize();
-                        n64flashcart::set_protocol(ProtocolVer::VERSION2);
-                        Some(FlashcartState::DISCONNECTED)
-                    } else if status != DeviceError::OK {
-                        Some(FlashcartState::DISCONNECTED)
+                    if let Some(attached_device) = device {
+                        let status = n64flashcart::connect(attached_device.vid, attached_device.pid, &attached_device.serial);
+                        if status == DeviceError::CARTFINDFAIL {
+                            n64flashcart::initialize();
+                            n64flashcart::set_protocol(ProtocolVer::VERSION2);
+                            Some(FlashcartState::DISCONNECTED)
+                        } else if status != DeviceError::OK {
+                            Some(FlashcartState::DISCONNECTED)
+                        } else {
+                            let cart_name = n64flashcart::cart_type_to_str(n64flashcart::get_cart());
+                            Some(FlashcartState::OPENING(cart_name.to_string()))
+                        }
                     } else {
-                        let cart_name = n64flashcart::cart_type_to_str(n64flashcart::get_cart());
-                        Some(FlashcartState::OPENING(cart_name.to_string()))
+                        None
                     }
                 },
                 FlashcartState::OPENING(name) => {
-                    let status = n64flashcart::open();
-                    if status != DeviceError::OK {
-                        dbg_println!("Failed to open USB connection to flashcart, retrying, error code {}", status.value());
-                        Some(FlashcartState::DISCONNECTED)
+                    if let Some(_) = device {
+                        let status = n64flashcart::open();
+                        if status != DeviceError::OK {
+                            dbg_println!("Failed to open USB connection to flashcart, retrying, error code {}", status.value());
+                            Some(FlashcartState::DISCONNECTED)
+                        } else {
+                            dbg_println!("Flashcart USB connection opened");
+                            Some(FlashcartState::CONNECTED(name.to_owned(), CommState::WaitForGame, Arc::new(FlashcartGuard)))
+                        }
                     } else {
-                        dbg_println!("Flashcart USB connection opened");
-                        Some(FlashcartState::CONNECTED(name.to_owned(), CommState::WaitForGame))
+                        Some(FlashcartState::SEARCHING)
                     }
                 },
-                FlashcartState::CONNECTED(name, comm_state) => {
-                    match read(name, comm_state).await {
-                        Ok((next_state, m)) => {
-                            messages.extend(m);
-                            next_state
-                        },
-                        Err(e) => {
-                            messages.push(Message::FlashcartCommError(Arc::new(vec![(name.to_owned(), ConnectError::DeviceError(e))])));
-                            Some(FlashcartState::CONNECTED(name.to_owned(), comm_state.to_owned()))
+                FlashcartState::CONNECTED(name, comm_state, guard) => {
+                    if let Some(_) = device {
+                        match read(comm_state).await {
+                            Ok((next_state, m)) => {
+                                messages.extend(m);
+                                match next_state {
+                                    Some(CommState::Disconnect) => Some(FlashcartState::DISCONNECTED),
+                                    Some(new_state) => Some(FlashcartState::CONNECTED(name.to_owned(), new_state, guard.to_owned())),
+                                    None => None,
+                                }
+                            },
+                            Err(e) => {
+                                messages.push(Message::FlashcartCommError(Arc::new(vec![ConnectError::DeviceError(e)])));
+                                Some(FlashcartState::CONNECTED(name.to_owned(), comm_state.to_owned(), guard.to_owned()))
+                            }
                         }
+                    } else {
+                        Some(FlashcartState::SEARCHING)
                     }
                 }
             };
@@ -670,7 +717,7 @@ impl Recipe for Subscription {
             }
 
             Ok::<_, ConnectError>(Some((stream::iter(messages).map(Ok::<_, ConnectError>), new_state.unwrap_or(state))))
-        }).try_flatten().map(|res| {
+        }}).try_flatten().map(|res| {
             let mut print_debug = true;
 
             if let Ok(message) = &res {

--- a/crate/multiworld-gui/src/flashcart.rs
+++ b/crate/multiworld-gui/src/flashcart.rs
@@ -250,6 +250,19 @@ async fn process_n64_packet(header: n64flashcart::Header, data: Vec<u8>, struc: 
             Ok((Some(InGameState::NotKnown), None))
         },
 
+        // Summercart menu responses are UNFloader-compatible.
+        // Everdrive gets filtered out by n64flashcart.
+        USBDataType::TEXT => {
+            if let Ok(text) = TryInto::<[u8 ; 6]>::try_into(data) {
+                match text {
+                    [b'j', b'o', b'y', b'b', b'u', b's'] => Ok((Some(InGameState::NotKnown), None)),
+                    _ => Err(DeviceError::SC64_FIRMWAREUNSUPPORTED),
+                }
+            } else {
+                Err(DeviceError::SC64_FIRMWAREUNSUPPORTED)
+            }
+        },
+
         USBDataType::SAVE_FILENAME => {
             if data.len() >= 8 {
                 let data_slice = data.into_boxed_slice();

--- a/crate/multiworld-gui/src/flashcart.rs
+++ b/crate/multiworld-gui/src/flashcart.rs
@@ -453,7 +453,17 @@ async fn process_n64_packet(header: n64flashcart::Header, data: Vec<u8>, struc: 
                 send_err().await;
                 Ok((None, None))
             }
-        }
+        },
+
+        USBDataType::SEND_HINT => {
+            send_ack().await;
+            Ok((None, None))
+        },
+
+        USBDataType::SEND_ENTRANCE => {
+            send_ack().await;
+            Ok((None, None))
+        },
 
         USBDataType::HEARTBEAT => Ok((None, None)),
 

--- a/crate/multiworld-gui/src/main.rs
+++ b/crate/multiworld-gui/src/main.rs
@@ -845,6 +845,12 @@ impl State {
             Message::FlashcartStateChanged(state) => {
                 println!("Flashcart state changed: {:?}", state);
                 self.frontend.flashcart.state = state;
+
+                if let Frontend::Flashcart = self.frontend.kind {
+                    if let FlashcartState::DISCONNECTED = self.frontend.flashcart.state {
+                        self.frontend_writer = None;
+                    }
+                }
             }
             Message::Exit => return iced::exit(),
             Message::FrontendConnected(inner) => {
@@ -1559,7 +1565,15 @@ impl State {
                         FlashcartState::DISCONNECTED => col = col.push("Disconnected from flashcart, waiting 5 seconds..."),
                         FlashcartState::SEARCHING => col = col.push("Looking for supported flashcarts"),
                         FlashcartState::OPENING(name) => col = col.push(Text::new(format!("Opening flashcart {}", name))),
-                        FlashcartState::CONNECTED(name, _) => col = col.push(Text::new(format!("Connected to flashcart {}", name))),
+                        FlashcartState::CONNECTED(name, comm_state) => {
+                            col = col.push(Text::new(format!("Connected to flashcart {}", name)));
+                            col = col.push(match comm_state {
+                                flashcart::CommState::SendHandshake => "Sending handshare",
+                                flashcart::CommState::WaitForGame => "Waiting for game...",
+                                flashcart::CommState::Handshake => "Waiting for handshake response",
+                                flashcart::CommState::Ready(_) => "Ready",
+                            })
+                        }
                     }
                 },
                 #[cfg(any(target_os = "linux", target_os = "windows"))] Frontend::BizHawk => if self.frontend.bizhawk.is_some() {

--- a/crate/multiworld-gui/src/main.rs
+++ b/crate/multiworld-gui/src/main.rs
@@ -310,8 +310,6 @@ enum Message {
     EverDriveScanFailed(Arc<Vec<(tokio_serial::SerialPortInfo, everdrive::ConnectError)>>),
     EverDriveTimeout,
     FlashcartStateChanged(FlashcartState),
-    #[expect(dead_code)]
-    FlashcartMessage(String),
     Exit,
     FrontendConnected(FrontendWriter),
     FrontendSubscriptionError(Arc<Error>),
@@ -839,11 +837,7 @@ impl State {
                     self.frontend_writer = None;
                 }
             },
-            Message::FlashcartMessage(message) => {
-                println!("Message from flashcart: {}", message);
-            },
             Message::FlashcartStateChanged(state) => {
-                println!("Flashcart state changed: {:?}", state);
                 self.frontend.flashcart.state = state;
 
                 if let Frontend::Flashcart = self.frontend.kind {

--- a/crate/multiworld-gui/src/main.rs
+++ b/crate/multiworld-gui/src/main.rs
@@ -137,6 +137,7 @@ use {
 #[cfg(target_os = "linux")] use std::os::unix::fs::PermissionsExt as _;
 
 mod everdrive;
+mod flashcart;
 mod login;
 mod persistent_state;
 mod subscriptions;
@@ -282,6 +283,7 @@ enum Error {
     #[error(transparent)] Config(#[from] multiworld::config::Error),
     #[error(transparent)] Elapsed(#[from] tokio::time::error::Elapsed),
     #[error(transparent)] EverDrive(#[from] everdrive::Error),
+    #[error(transparent)] Flashcart(#[from] flashcart::Error),
     #[error(transparent)] Http(#[from] tungstenite::http::Error),
     #[error(transparent)] InvalidUri(#[from] tungstenite::http::uri::InvalidUri),
     #[error(transparent)] Io(#[from] io::Error),
@@ -313,7 +315,7 @@ impl IsNetworkError for Error {
     fn is_network_error(&self) -> bool {
         match self {
             Self::Elapsed(_) => true,
-            Self::Config(_) | Self::EverDrive(_) | Self::Http(_) | Self::InvalidUri(_) | Self::Json(_) | Self::MpscFrontendSend(_) | Self::PersistentState(_) | Self::Semver(_) | Self::Url(_) | Self::InvalidPj64ScriptPath | Self::VersionMismatch { .. } => false,
+            Self::Config(_) | Self::EverDrive(_) | Self::Flashcart(_) | Self::Http(_) | Self::InvalidUri(_) | Self::Json(_) | Self::MpscFrontendSend(_) | Self::PersistentState(_) | Self::Semver(_) | Self::Url(_) | Self::InvalidPj64ScriptPath | Self::VersionMismatch { .. } => false,
             Self::Client(e) => e.is_network_error(),
             Self::Io(e) | Self::Pj64LaunchFailed(e) => e.is_network_error(),
             Self::Read(e) => e.is_network_error(),
@@ -612,6 +614,7 @@ impl FrontendState {
         match self.kind {
             Frontend::Dummy => "(no frontend)".into(),
             Frontend::EverDrive => "EverDrive".into(),
+            Frontend::Flashcart => "Flashcart".into(),
             #[cfg(any(target_os = "linux", target_os = "windows"))] Frontend::BizHawk => if let Some(BizHawkState { ref version, .. }) = self.bizhawk {
                 format!("BizHawk {version}").into()
             } else {
@@ -626,6 +629,7 @@ impl FrontendState {
     fn is_locked(&self) -> bool {
         match self.kind {
             Frontend::Dummy | Frontend::EverDrive | Frontend::Pj64V3 => false,
+            Frontend::Flashcart => false,
             Frontend::Pj64V4 => false, //TODO pass port from PJ64, consider locked if present
             #[cfg(any(target_os = "linux", target_os = "windows"))] Frontend::BizHawk => self.bizhawk.is_some(),
             #[cfg(not(any(target_os = "linux", target_os = "windows")))] Frontend::BizHawk => unreachable!("no BizHawk support on this platform"),
@@ -753,7 +757,8 @@ impl State {
                                         cmd.arg("everdrive");
                                         cmd.arg(env::current_exe()?);
                                         cmd.arg(process::id().to_string());
-                                    }
+                                    },
+                                    Frontend::Flashcart => return Ok(Message::UpToDate),
                                     Frontend::BizHawk => if let Some(BizHawkState { path, pid, version, port: _ }) = frontend.bizhawk {
                                         cmd.arg("bizhawk");
                                         cmd.arg(process::id().to_string());
@@ -1564,6 +1569,9 @@ impl State {
                         .push("Connection to EverDrive lost")
                         .push("Retrying in 5 seconds…"),
                 },
+                Frontend::Flashcart => {
+                    col = col.push("Looking for supported flashcarts");
+                },
                 #[cfg(any(target_os = "linux", target_os = "windows"))] Frontend::BizHawk => if self.frontend.bizhawk.is_some() {
                     col = col
                         .push("Waiting for BizHawk…")
@@ -1590,7 +1598,7 @@ impl State {
                 }
                 Frontend::Pj64V4 => {
                     col = col
-                        .push("Waiting for Project64…")
+                        .push("Waiting forFrontend::Dummy => {} Project64…")
                         .push("This should take less than 5 seconds.");
                 }
             }
@@ -2045,10 +2053,11 @@ impl State {
         if !matches!(self.update_state, UpdateState::Pending) {
             match self.frontend.kind {
                 Frontend::Dummy => {}
-                Frontend::EverDrive => subscriptions.push(subscription::from_recipe(LoggingSubscription { log: self.log, context: "from EverDrive", inner: everdrive::Subscription { log: self.log } })),
+                Frontend::EverDrive => subscriptions.push(subscription::from_recipe(LoggingSubscription { log: true, context: "from EverDrive", inner: everdrive::Subscription { log: self.log } })),
                 #[cfg(any(target_os = "linux", target_os = "windows"))] Frontend::BizHawk => if let Some(BizHawkState { port, .. }) = self.frontend.bizhawk {
                     subscriptions.push(subscription::from_recipe(LoggingSubscription { log: self.log, context: "from BizHawk", inner: subscriptions::Connection { port, frontend: self.frontend.kind, log: self.log, connection_id: self.frontend_connection_id } }));
                 },
+                Frontend::Flashcart => subscriptions.push(subscription::from_recipe(LoggingSubscription { log: self.log, context: "from Flashcart", inner: flashcart::Subscription { /*log: self.log */ } })),
                 #[cfg(not(any(target_os = "linux", target_os = "windows")))] Frontend::BizHawk => unreachable!("no BizHawk support on this platform"),
                 Frontend::Pj64V3 => subscriptions.push(subscription::from_recipe(LoggingSubscription { log: self.log, context: "from Project64", inner: subscriptions::Listener { frontend: self.frontend.kind, log: self.log, connection_id: self.frontend_connection_id } })),
                 Frontend::Pj64V4 => subscriptions.push(subscription::from_recipe(LoggingSubscription { log: self.log, context: "from Project64", inner: subscriptions::Connection { port: frontend::PORT, frontend: self.frontend.kind, log: self.log, connection_id: self.frontend_connection_id } })), //TODO allow Project64 to specify port via command-line arg

--- a/crate/multiworld-gui/src/main.rs
+++ b/crate/multiworld-gui/src/main.rs
@@ -1,106 +1,30 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 use {
-    std::{
-        borrow::Cow,
-        cell::RefCell,
-        collections::{
-            BTreeMap,
-            HashMap,
-            HashSet,
-        },
-        env,
-        fmt,
-        future::Future,
-        io::prelude::*,
-        mem,
-        num::NonZeroU8,
-        path::{
-            Path,
-            PathBuf,
-        },
-        process,
-        sync::Arc,
-        time::Duration,
-    },
-    async_proto::Protocol,
-    chrono::{
+    crate::{
+        flashcart::FlashcartState, persistent_state::PersistentState, subscriptions::{
+            LoggingSubscription,
+            WsSink,
+        }
+    }, async_proto::Protocol, chrono::{
         TimeDelta,
         prelude::*,
-    },
-    enum_iterator::all,
-    futures::{
+    }, enum_iterator::all, futures::{
         future::{
             self,
             FutureExt as _,
         },
         sink::SinkExt as _,
         stream::Stream,
-    },
-    iced::{
-        Element,
-        Length,
-        Task,
-        Size,
-        Subscription,
-        advanced::subscription,
-        clipboard,
-        widget::*,
-        window::{
+    }, iced::{
+        Element, Length, Size, Subscription, Task, advanced::subscription, clipboard, widget::*, window::{
             self,
             icon,
-        },
-    },
-    if_chain::if_chain,
-    ::image::ImageFormat,
-    itertools::Itertools as _,
-    log_lock::{
+        }
+    }, if_chain::if_chain, ::image::ImageFormat, itertools::Itertools as _, log_lock::{
         Mutex,
         lock,
-    },
-    oauth2::{
-        RefreshToken,
-        TokenResponse as _,
-        reqwest::async_http_client,
-    },
-    once_cell::sync::Lazy,
-    ootr::model::{
-        DungeonReward,
-        Medallion,
-        Stone,
-    },
-    ootr_utils::spoiler::HashIcon,
-    open::that as open,
-    rand::{
-        prelude::*,
-        rng,
-    },
-    rfd::AsyncFileDialog,
-    semver::Version,
-    serenity::utils::MessageBuilder,
-    sysinfo::Pid,
-    tokio::{
-        io::{
-            self,
-            AsyncWriteExt as _,
-        },
-        net::tcp::{
-            OwnedReadHalf,
-            OwnedWriteHalf,
-        },
-        sync::mpsc,
-        time::{
-            Instant,
-            sleep_until,
-        },
-    },
-    tokio_tungstenite::tungstenite,
-    url::Url,
-    wheel::{
-        fs,
-        traits::IsNetworkError,
-    },
-    multiworld::{
+    }, multiworld::{
         DurationFormatter,
         Filename,
         HintArea,
@@ -123,14 +47,56 @@ use {
                 ServerMessage,
             },
         },
-    },
-    crate::{
-        persistent_state::PersistentState,
-        subscriptions::{
-            LoggingSubscription,
-            WsSink,
+    }, oauth2::{
+        RefreshToken,
+        TokenResponse as _,
+        reqwest::async_http_client,
+    }, once_cell::sync::Lazy, ootr::model::{
+        DungeonReward,
+        Medallion,
+        Stone,
+    }, ootr_utils::spoiler::HashIcon, open::that as open, rand::{
+        prelude::*,
+        rng,
+    }, rfd::AsyncFileDialog, semver::Version, serenity::utils::MessageBuilder, std::{
+        borrow::Cow,
+        cell::RefCell,
+        collections::{
+            BTreeMap,
+            HashMap,
+            HashSet,
         },
-    },
+        env,
+        fmt,
+        future::Future,
+        io::prelude::*,
+        mem,
+        num::NonZeroU8,
+        path::{
+            Path,
+            PathBuf,
+        },
+        process,
+        sync::Arc,
+        time::Duration,
+    }, sysinfo::Pid, tokio::{
+        io::{
+            self,
+            AsyncWriteExt as _,
+        },
+        net::tcp::{
+            OwnedReadHalf,
+            OwnedWriteHalf,
+        },
+        sync::mpsc,
+        time::{
+            Instant,
+            sleep_until,
+        },
+    }, tokio_tungstenite::tungstenite, url::Url, wheel::{
+        fs,
+        traits::IsNetworkError,
+    }
 };
 #[cfg(unix)] use xdg::BaseDirectories;
 #[cfg(windows)] use directories::ProjectDirs;
@@ -343,6 +309,9 @@ enum Message {
     DismissWrongPassword,
     EverDriveScanFailed(Arc<Vec<(tokio_serial::SerialPortInfo, everdrive::ConnectError)>>),
     EverDriveTimeout,
+    FlashcartStateChanged(FlashcartState),
+    #[expect(dead_code)]
+    FlashcartMessage(String),
     Exit,
     FrontendConnected(FrontendWriter),
     FrontendSubscriptionError(Arc<Error>),
@@ -602,11 +571,17 @@ enum EverDriveState {
 }
 
 #[derive(Debug, Clone)]
+struct FrontendFlashcartState {
+    state: FlashcartState
+}
+
+#[derive(Debug, Clone)]
 struct FrontendState {
     kind: Frontend,
     #[cfg(any(target_os = "linux", target_os = "windows"))]
     bizhawk: Option<BizHawkState>,
     everdrive: EverDriveState,
+    flashcart: FrontendFlashcartState,
 }
 
 impl FrontendState {
@@ -666,6 +641,9 @@ impl State {
                 None
             },
             everdrive: EverDriveState::default(),
+            flashcart: FrontendFlashcartState {
+                state: FlashcartState::DISCONNECTED
+            }
         };
         Self {
             debug_info_copied: HashSet::default(),
@@ -860,6 +838,13 @@ impl State {
                 if let Frontend::EverDrive = self.frontend.kind {
                     self.frontend_writer = None;
                 }
+            },
+            Message::FlashcartMessage(message) => {
+                println!("Message from flashcart: {}", message);
+            },
+            Message::FlashcartStateChanged(state) => {
+                println!("Flashcart state changed: {:?}", state);
+                self.frontend.flashcart.state = state;
             }
             Message::Exit => return iced::exit(),
             Message::FrontendConnected(inner) => {
@@ -1570,7 +1555,12 @@ impl State {
                         .push("Retrying in 5 seconds…"),
                 },
                 Frontend::Flashcart => {
-                    col = col.push("Looking for supported flashcarts");
+                    match &self.frontend.flashcart.state {
+                        FlashcartState::DISCONNECTED => col = col.push("Disconnected from flashcart, waiting 5 seconds..."),
+                        FlashcartState::SEARCHING => col = col.push("Looking for supported flashcarts"),
+                        FlashcartState::OPENING(name) => col = col.push(Text::new(format!("Opening flashcart {}", name))),
+                        FlashcartState::CONNECTED(name) => col = col.push(Text::new(format!("Connected to flashcart {}", name))),
+                    }
                 },
                 #[cfg(any(target_os = "linux", target_os = "windows"))] Frontend::BizHawk => if self.frontend.bizhawk.is_some() {
                     col = col

--- a/crate/multiworld-gui/src/main.rs
+++ b/crate/multiworld-gui/src/main.rs
@@ -1559,7 +1559,7 @@ impl State {
                         FlashcartState::DISCONNECTED => col = col.push("Disconnected from flashcart, waiting 5 seconds..."),
                         FlashcartState::SEARCHING => col = col.push("Looking for supported flashcarts"),
                         FlashcartState::OPENING(name) => col = col.push(Text::new(format!("Opening flashcart {}", name))),
-                        FlashcartState::CONNECTED(name) => col = col.push(Text::new(format!("Connected to flashcart {}", name))),
+                        FlashcartState::CONNECTED(name, _) => col = col.push(Text::new(format!("Connected to flashcart {}", name))),
                     }
                 },
                 #[cfg(any(target_os = "linux", target_os = "windows"))] Frontend::BizHawk => if self.frontend.bizhawk.is_some() {

--- a/crate/multiworld-gui/src/main.rs
+++ b/crate/multiworld-gui/src/main.rs
@@ -249,7 +249,7 @@ enum Error {
     #[error(transparent)] Config(#[from] multiworld::config::Error),
     #[error(transparent)] Elapsed(#[from] tokio::time::error::Elapsed),
     #[error(transparent)] EverDrive(#[from] everdrive::Error),
-    #[error(transparent)] Flashcart(#[from] flashcart::Error),
+    #[error(transparent)] Flashcart(#[from] flashcart::ConnectError),
     #[error(transparent)] Http(#[from] tungstenite::http::Error),
     #[error(transparent)] InvalidUri(#[from] tungstenite::http::uri::InvalidUri),
     #[error(transparent)] Io(#[from] io::Error),
@@ -309,8 +309,11 @@ enum Message {
     DismissWrongPassword,
     EverDriveScanFailed(Arc<Vec<(tokio_serial::SerialPortInfo, everdrive::ConnectError)>>),
     EverDriveTimeout,
-    FlashcartStateChanged(FlashcartState),
     Exit,
+    FlashcartHandshakeFailed(Arc<Vec<(String, flashcart::ConnectError)>>),
+    FlashcartHandshakeSuccessful(),
+    FlashcartCommError(Arc<Vec<(String, flashcart::ConnectError)>>),
+    FlashcartStateChanged(FlashcartState),
     FrontendConnected(FrontendWriter),
     FrontendSubscriptionError(Arc<Error>),
     JoinRoom,
@@ -514,6 +517,20 @@ impl State {
                     }
                     builder.build()
                 }
+            } else if self.frontend_writer.is_none() && self.frontend.kind != Frontend::Dummy && matches!(self.frontend.kind, Frontend::Flashcart) && !self.frontend.flashcart.errors.is_empty() {
+                let errors = &self.frontend.flashcart.errors;
+                let mut builder = MessageBuilder::default();
+                builder.push(format!("error in Mido's House Multiworld version {}{} while talking to flashcart:", env!("CARGO_PKG_VERSION"), {
+                    #[cfg(debug_assertions)] { " (debug)" }
+                    #[cfg(not(debug_assertions))] { "" }
+                }));
+                for (name, error) in &**errors {
+                    builder.push_line("");
+                    builder.push_mono_safe(name);
+                    builder.push_line(':');
+                    builder.push_codeblock_safe(format!("{error:?}"), Some("rust"));
+                }
+                builder.build()
             } else {
                 match self.server_connection {
                     SessionState::Error { ref e, .. } => MessageBuilder::default()
@@ -570,7 +587,8 @@ enum EverDriveState {
 
 #[derive(Debug, Clone)]
 struct FrontendFlashcartState {
-    state: FlashcartState
+    state: FlashcartState,
+    errors: Arc<Vec<(String, flashcart::ConnectError)>>,
 }
 
 #[derive(Debug, Clone)]
@@ -640,7 +658,8 @@ impl State {
             },
             everdrive: EverDriveState::default(),
             flashcart: FrontendFlashcartState {
-                state: FlashcartState::DISCONNECTED
+                state: FlashcartState::DISCONNECTED,
+                errors: Arc::new(vec![]),
             }
         };
         Self {
@@ -836,6 +855,15 @@ impl State {
                 if let Frontend::EverDrive = self.frontend.kind {
                     self.frontend_writer = None;
                 }
+            },
+            Message::FlashcartCommError(errors) => {
+                self.frontend.flashcart.errors = errors;
+            },
+            Message::FlashcartHandshakeFailed(errors) => {
+                self.frontend.flashcart.errors = errors;
+            },
+            Message::FlashcartHandshakeSuccessful() => {
+                self.frontend.flashcart.errors = Arc::new(vec![]);
             },
             Message::FlashcartStateChanged(state) => {
                 self.frontend.flashcart.state = state;
@@ -1562,8 +1590,8 @@ impl State {
                         FlashcartState::CONNECTED(name, comm_state) => {
                             col = col.push(Text::new(format!("Connected to flashcart {}", name)));
                             col = col.push(match comm_state {
-                                flashcart::CommState::SendHandshake => "Sending handshare",
                                 flashcart::CommState::WaitForGame => "Waiting for game...",
+                                flashcart::CommState::SendHandshake => "Sending handshake",
                                 flashcart::CommState::Handshake => "Waiting for handshake response",
                                 flashcart::CommState::Ready(_) => "Ready",
                             })
@@ -2055,7 +2083,7 @@ impl State {
                 #[cfg(any(target_os = "linux", target_os = "windows"))] Frontend::BizHawk => if let Some(BizHawkState { port, .. }) = self.frontend.bizhawk {
                     subscriptions.push(subscription::from_recipe(LoggingSubscription { log: self.log, context: "from BizHawk", inner: subscriptions::Connection { port, frontend: self.frontend.kind, log: self.log, connection_id: self.frontend_connection_id } }));
                 },
-                Frontend::Flashcart => subscriptions.push(subscription::from_recipe(LoggingSubscription { log: self.log, context: "from Flashcart", inner: flashcart::Subscription { /*log: self.log */ } })),
+                Frontend::Flashcart => subscriptions.push(subscription::from_recipe(LoggingSubscription { log: self.log, context: "from Flashcart", inner: flashcart::Subscription { log: self.log } })),
                 #[cfg(not(any(target_os = "linux", target_os = "windows")))] Frontend::BizHawk => unreachable!("no BizHawk support on this platform"),
                 Frontend::Pj64V3 => subscriptions.push(subscription::from_recipe(LoggingSubscription { log: self.log, context: "from Project64", inner: subscriptions::Listener { frontend: self.frontend.kind, log: self.log, connection_id: self.frontend_connection_id } })),
                 Frontend::Pj64V4 => subscriptions.push(subscription::from_recipe(LoggingSubscription { log: self.log, context: "from Project64", inner: subscriptions::Connection { port: frontend::PORT, frontend: self.frontend.kind, log: self.log, connection_id: self.frontend_connection_id } })), //TODO allow Project64 to specify port via command-line arg

--- a/crate/multiworld-gui/src/main.rs
+++ b/crate/multiworld-gui/src/main.rs
@@ -884,7 +884,7 @@ impl State {
 
                 if let Frontend::Flashcart = self.frontend.kind {
                     match self.frontend.flashcart.state {
-                        FlashcartState::DISCONNECTED(_) | FlashcartState::SEARCHING(_) => self.frontend_writer = None,
+                        FlashcartState::DISCONNECTED{ .. } | FlashcartState::SEARCHING{ .. } => self.frontend_writer = None,
                         _ => {}
                     }
                 }
@@ -1618,17 +1618,17 @@ impl State {
                     }
                     match &self.frontend.flashcart.state {
                         FlashcartState::INITIALIZE => col = col.push("Starting flashcart connection"),
-                        FlashcartState::DISCONNECTED(_) => col = col.push("Disconnected from flashcart, waiting 5 seconds..."),
-                        FlashcartState::SEARCHING(_) => col = col.push("Looking for supported flashcarts"),
-                        FlashcartState::OPENING(name,_) => col = col.push(Text::new(format!("Opening flashcart {}", name))),
-                        FlashcartState::CONNECTED(name, comm_state, _, _) => {
-                            col = col.push(Text::new(format!("Connected to flashcart {}", name)));
-                            col = col.push(match comm_state {
+                        FlashcartState::DISCONNECTED{ .. } => col = col.push("Disconnected from flashcart, waiting 5 seconds..."),
+                        FlashcartState::SEARCHING{ .. } => col = col.push("Looking for supported flashcarts"),
+                        FlashcartState::OPENING{ cart_name, .. } => col = col.push(Text::new(format!("Opening flashcart {}", cart_name))),
+                        FlashcartState::CONNECTED{ cart_name, connection_state, .. } => {
+                            col = col.push(Text::new(format!("Connected to flashcart {}", cart_name)));
+                            col = col.push(match connection_state {
                                 flashcart::CommState::Disconnect => "Lost connection",
                                 flashcart::CommState::WaitForGame => "Waiting for game...",
                                 flashcart::CommState::SendHandshake => "Sending handshake",
                                 flashcart::CommState::Handshake => "Waiting for handshake response",
-                                flashcart::CommState::Ready(_) => "Ready",
+                                flashcart::CommState::Ready{ .. } => "Ready",
                             })
                         }
                     }
@@ -1659,7 +1659,7 @@ impl State {
                 }
                 Frontend::Pj64V4 => {
                     col = col
-                        .push("Waiting forFrontend::Dummy => {} Project64…")
+                        .push("Waiting for Project64…")
                         .push("This should take less than 5 seconds.");
                 }
             }

--- a/crate/multiworld-gui/src/main.rs
+++ b/crate/multiworld-gui/src/main.rs
@@ -17,7 +17,7 @@ use {
         sink::SinkExt as _,
         stream::Stream,
     }, iced::{
-        Element, Length, Size, Subscription, Task, advanced::subscription, clipboard, widget::*, window::{
+        Element, Length, Size, Padding, Subscription, Task, advanced::subscription, clipboard, widget::*, window::{
             self,
             icon,
         }
@@ -47,7 +47,8 @@ use {
                 ServerMessage,
             },
         },
-    }, oauth2::{
+    }, n64flashcart::UsbSerialPort,
+    oauth2::{
         RefreshToken,
         TokenResponse as _,
         reqwest::async_http_client,
@@ -96,7 +97,7 @@ use {
     }, tokio_tungstenite::tungstenite, url::Url, wheel::{
         fs,
         traits::IsNetworkError,
-    }
+    },
 };
 #[cfg(unix)] use xdg::BaseDirectories;
 #[cfg(windows)] use directories::ProjectDirs;
@@ -310,9 +311,9 @@ enum Message {
     EverDriveScanFailed(Arc<Vec<(tokio_serial::SerialPortInfo, everdrive::ConnectError)>>),
     EverDriveTimeout,
     Exit,
-    FlashcartHandshakeFailed(Arc<Vec<(String, flashcart::ConnectError)>>),
+    FlashcartHandshakeFailed(Arc<Vec<flashcart::ConnectError>>),
     FlashcartHandshakeSuccessful(),
-    FlashcartCommError(Arc<Vec<(String, flashcart::ConnectError)>>),
+    FlashcartCommError(Arc<Vec<flashcart::ConnectError>>),
     FlashcartStateChanged(FlashcartState),
     FrontendConnected(FrontendWriter),
     FrontendSubscriptionError(Arc<Error>),
@@ -345,6 +346,7 @@ enum Message {
     SetAutoDeleteDelta(DurationFormatter),
     SetCreateNewRoom(bool),
     SetExistingRoomSelection(RoomFormatter),
+    SetFlashcartDevice(UsbSerialPort),
     SetFrontend(Frontend),
     SetLobbyView(LobbyView),
     SetMaintenanceDontShowAgain(bool),
@@ -524,9 +526,8 @@ impl State {
                     #[cfg(debug_assertions)] { " (debug)" }
                     #[cfg(not(debug_assertions))] { "" }
                 }));
-                for (name, error) in &**errors {
+                for error in &**errors {
                     builder.push_line("");
-                    builder.push_mono_safe(name);
                     builder.push_line(':');
                     builder.push_codeblock_safe(format!("{error:?}"), Some("rust"));
                 }
@@ -588,7 +589,9 @@ enum EverDriveState {
 #[derive(Debug, Clone)]
 struct FrontendFlashcartState {
     state: FlashcartState,
-    errors: Arc<Vec<(String, flashcart::ConnectError)>>,
+    errors: Arc<Vec<flashcart::ConnectError>>,
+    device: Option<UsbSerialPort>,
+    device_list: Vec<UsbSerialPort>,
 }
 
 #[derive(Debug, Clone)]
@@ -605,7 +608,7 @@ impl FrontendState {
         match self.kind {
             Frontend::Dummy => "(no frontend)".into(),
             Frontend::EverDrive => "EverDrive".into(),
-            Frontend::Flashcart => "Flashcart".into(),
+            Frontend::Flashcart => "Console".into(),
             #[cfg(any(target_os = "linux", target_os = "windows"))] Frontend::BizHawk => if let Some(BizHawkState { ref version, .. }) = self.bizhawk {
                 format!("BizHawk {version}").into()
             } else {
@@ -642,10 +645,11 @@ impl State {
             kind: match frontend {
                 None => config.default_frontend.unwrap_or({
                     #[cfg(windows)] { Frontend::Pj64V3 }
-                    #[cfg(not(windows))] { Frontend::EverDrive }
+                    #[cfg(not(windows))] { Frontend::Flashcart }
                 }),
                 Some(FrontendArgs::Dummy) => Frontend::Dummy,
                 Some(FrontendArgs::EverDrive) => Frontend::EverDrive,
+                Some(FrontendArgs::Flashcart) => Frontend::Flashcart,
                 Some(FrontendArgs::BizHawk { .. }) => Frontend::BizHawk,
                 Some(FrontendArgs::Pj64V3) => Frontend::Pj64V3,
                 Some(FrontendArgs::Pj64V4) => Frontend::Pj64V4,
@@ -660,6 +664,8 @@ impl State {
             flashcart: FrontendFlashcartState {
                 state: FlashcartState::DISCONNECTED,
                 errors: Arc::new(vec![]),
+                device: None,
+                device_list: n64flashcart::list(),
             }
         };
         Self {
@@ -753,7 +759,11 @@ impl State {
                                         cmd.arg(env::current_exe()?);
                                         cmd.arg(process::id().to_string());
                                     },
-                                    Frontend::Flashcart => return Ok(Message::UpToDate),
+                                    Frontend::Flashcart => {
+                                        cmd.arg("flashcart");
+                                        cmd.arg(env::current_exe()?);
+                                        cmd.arg(process::id().to_string());
+                                    },
                                     Frontend::BizHawk => if let Some(BizHawkState { path, pid, version, port: _ }) = frontend.bizhawk {
                                         cmd.arg("bizhawk");
                                         cmd.arg(process::id().to_string());
@@ -856,6 +866,7 @@ impl State {
                     self.frontend_writer = None;
                 }
             },
+            Message::Exit => return iced::exit(),
             Message::FlashcartCommError(errors) => {
                 self.frontend.flashcart.errors = errors;
             },
@@ -869,12 +880,12 @@ impl State {
                 self.frontend.flashcart.state = state;
 
                 if let Frontend::Flashcart = self.frontend.kind {
-                    if let FlashcartState::DISCONNECTED = self.frontend.flashcart.state {
-                        self.frontend_writer = None;
+                    match self.frontend.flashcart.state {
+                        FlashcartState::DISCONNECTED | FlashcartState::SEARCHING => self.frontend_writer = None,
+                        _ => {}
                     }
                 }
             }
-            Message::Exit => return iced::exit(),
             Message::FrontendConnected(inner) => {
                 if let Frontend::EverDrive = self.frontend.kind {
                     self.frontend.everdrive = EverDriveState::Connected;
@@ -1453,6 +1464,7 @@ impl State {
                 }
                 self.show_room_filter = false;
             },
+            Message::SetFlashcartDevice(new_device) => self.frontend.flashcart.device = Some(new_device),
             Message::SetFrontend(new_frontend) => self.frontend.kind = new_frontend,
             Message::SetMaintenanceDontShowAgain(dont_show_again) => self.maintenance_dont_show_again = dont_show_again,
             Message::SetNewRoomName(name) => if let SessionState::Lobby { ref mut new_room_name, .. } = self.server_connection { *new_room_name = name },
@@ -1583,13 +1595,19 @@ impl State {
                         .push("Retrying in 5 seconds…"),
                 },
                 Frontend::Flashcart => {
+                    col = col.push(PickList::new(
+                        self.frontend.flashcart.device_list.clone(),
+                        self.frontend.flashcart.device.clone(),
+                        Message::SetFlashcartDevice).padding(Padding {top: 5.0, right: 20.0, bottom: 30.0, left: 10.0}));
                     match &self.frontend.flashcart.state {
+                        FlashcartState::INITIALIZE => col = col.push("Starting flashcart connection"),
                         FlashcartState::DISCONNECTED => col = col.push("Disconnected from flashcart, waiting 5 seconds..."),
                         FlashcartState::SEARCHING => col = col.push("Looking for supported flashcarts"),
                         FlashcartState::OPENING(name) => col = col.push(Text::new(format!("Opening flashcart {}", name))),
-                        FlashcartState::CONNECTED(name, comm_state) => {
+                        FlashcartState::CONNECTED(name, comm_state, _) => {
                             col = col.push(Text::new(format!("Connected to flashcart {}", name)));
                             col = col.push(match comm_state {
+                                flashcart::CommState::Disconnect => "Lost connection",
                                 flashcart::CommState::WaitForGame => "Waiting for game...",
                                 flashcart::CommState::SendHandshake => "Sending handshake",
                                 flashcart::CommState::Handshake => "Waiting for handshake response",
@@ -2083,7 +2101,7 @@ impl State {
                 #[cfg(any(target_os = "linux", target_os = "windows"))] Frontend::BizHawk => if let Some(BizHawkState { port, .. }) = self.frontend.bizhawk {
                     subscriptions.push(subscription::from_recipe(LoggingSubscription { log: self.log, context: "from BizHawk", inner: subscriptions::Connection { port, frontend: self.frontend.kind, log: self.log, connection_id: self.frontend_connection_id } }));
                 },
-                Frontend::Flashcart => subscriptions.push(subscription::from_recipe(LoggingSubscription { log: self.log, context: "from Flashcart", inner: flashcart::Subscription { log: self.log } })),
+                Frontend::Flashcart => subscriptions.push(subscription::from_recipe(LoggingSubscription { log: self.log, context: "from Flashcart", inner: flashcart::Subscription { log: self.log, device: self.frontend.flashcart.device.clone() } })),
                 #[cfg(not(any(target_os = "linux", target_os = "windows")))] Frontend::BizHawk => unreachable!("no BizHawk support on this platform"),
                 Frontend::Pj64V3 => subscriptions.push(subscription::from_recipe(LoggingSubscription { log: self.log, context: "from Project64", inner: subscriptions::Listener { frontend: self.frontend.kind, log: self.log, connection_id: self.frontend_connection_id } })),
                 Frontend::Pj64V4 => subscriptions.push(subscription::from_recipe(LoggingSubscription { log: self.log, context: "from Project64", inner: subscriptions::Connection { port: frontend::PORT, frontend: self.frontend.kind, log: self.log, connection_id: self.frontend_connection_id } })), //TODO allow Project64 to specify port via command-line arg
@@ -2135,6 +2153,7 @@ enum FrontendArgs {
     #[clap(name = "dummy-frontend")]
     Dummy,
     EverDrive,
+    Flashcart,
     BizHawk {
         path: PathBuf,
         pid: Pid,

--- a/crate/multiworld-gui/src/main.rs
+++ b/crate/multiworld-gui/src/main.rs
@@ -664,7 +664,7 @@ impl State {
             },
             everdrive: EverDriveState::default(),
             flashcart: FrontendFlashcartState {
-                state: FlashcartState::DISCONNECTED,
+                state: FlashcartState::INITIALIZE,
                 errors: Arc::new(vec![]),
                 device: None,
                 device_list: n64flashcart::list(),
@@ -884,7 +884,7 @@ impl State {
 
                 if let Frontend::Flashcart = self.frontend.kind {
                     match self.frontend.flashcart.state {
-                        FlashcartState::DISCONNECTED | FlashcartState::SEARCHING => self.frontend_writer = None,
+                        FlashcartState::DISCONNECTED(_) | FlashcartState::SEARCHING(_) => self.frontend_writer = None,
                         _ => {}
                     }
                 }
@@ -1618,10 +1618,10 @@ impl State {
                     }
                     match &self.frontend.flashcart.state {
                         FlashcartState::INITIALIZE => col = col.push("Starting flashcart connection"),
-                        FlashcartState::DISCONNECTED => col = col.push("Disconnected from flashcart, waiting 5 seconds..."),
-                        FlashcartState::SEARCHING => col = col.push("Looking for supported flashcarts"),
-                        FlashcartState::OPENING(name) => col = col.push(Text::new(format!("Opening flashcart {}", name))),
-                        FlashcartState::CONNECTED(name, comm_state, _) => {
+                        FlashcartState::DISCONNECTED(_) => col = col.push("Disconnected from flashcart, waiting 5 seconds..."),
+                        FlashcartState::SEARCHING(_) => col = col.push("Looking for supported flashcarts"),
+                        FlashcartState::OPENING(name,_) => col = col.push(Text::new(format!("Opening flashcart {}", name))),
+                        FlashcartState::CONNECTED(name, comm_state, _, _) => {
                             col = col.push(Text::new(format!("Connected to flashcart {}", name)));
                             col = col.push(match comm_state {
                                 flashcart::CommState::Disconnect => "Lost connection",

--- a/crate/multiworld-gui/src/main.rs
+++ b/crate/multiworld-gui/src/main.rs
@@ -315,6 +315,7 @@ enum Message {
     FlashcartHandshakeSuccessful(),
     FlashcartCommError(Arc<Vec<flashcart::ConnectError>>),
     FlashcartStateChanged(FlashcartState),
+    FlashcartLocked,
     FrontendConnected(FrontendWriter),
     FrontendSubscriptionError(Arc<Error>),
     JoinRoom,
@@ -592,6 +593,7 @@ struct FrontendFlashcartState {
     errors: Arc<Vec<flashcart::ConnectError>>,
     device: Option<UsbSerialPort>,
     device_list: Vec<UsbSerialPort>,
+    device_locked: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -666,6 +668,7 @@ impl State {
                 errors: Arc::new(vec![]),
                 device: None,
                 device_list: n64flashcart::list(),
+                device_locked: false,
             }
         };
         Self {
@@ -885,6 +888,9 @@ impl State {
                         _ => {}
                     }
                 }
+            },
+            Message::FlashcartLocked => {
+                self.frontend.flashcart.device_locked = true;
             }
             Message::FrontendConnected(inner) => {
                 if let Frontend::EverDrive = self.frontend.kind {
@@ -1464,8 +1470,16 @@ impl State {
                 }
                 self.show_room_filter = false;
             },
-            Message::SetFlashcartDevice(new_device) => self.frontend.flashcart.device = Some(new_device),
-            Message::SetFrontend(new_frontend) => self.frontend.kind = new_frontend,
+            Message::SetFlashcartDevice(new_device) => {
+                self.frontend.flashcart.device = Some(new_device);
+                self.frontend.flashcart.device_locked = false;
+            },
+            Message::SetFrontend(new_frontend) => {
+                if let Frontend::Flashcart = self.frontend.kind {
+                    self.frontend.flashcart.device = None;
+                }
+                self.frontend.kind = new_frontend;
+            }
             Message::SetMaintenanceDontShowAgain(dont_show_again) => self.maintenance_dont_show_again = dont_show_again,
             Message::SetNewRoomName(name) => if let SessionState::Lobby { ref mut new_room_name, .. } = self.server_connection { *new_room_name = name },
             Message::SetPassword(new_password) => if let SessionState::Lobby { ref mut password, .. } = self.server_connection { *password = new_password },
@@ -1599,6 +1613,9 @@ impl State {
                         self.frontend.flashcart.device_list.clone(),
                         self.frontend.flashcart.device.clone(),
                         Message::SetFlashcartDevice).padding(Padding {top: 5.0, right: 20.0, bottom: 30.0, left: 10.0}));
+                    if self.frontend.flashcart.device_locked {
+                        col = col.push("Selected device is currently locked. Restart the app or use another device.");
+                    }
                     match &self.frontend.flashcart.state {
                         FlashcartState::INITIALIZE => col = col.push("Starting flashcart connection"),
                         FlashcartState::DISCONNECTED => col = col.push("Disconnected from flashcart, waiting 5 seconds..."),

--- a/crate/multiworld-installer/src/main.rs
+++ b/crate/multiworld-installer/src/main.rs
@@ -329,11 +329,12 @@ impl State {
                 Page::InstallEmulator { .. } => unreachable!(),
                 Page::LocateMultiworld { emulator, ref emulator_path, ref multiworld_path } => match emulator {
                     Emulator::Dummy => unreachable!(),
+                    Emulator::Flashcart => todo!(),
                     Emulator::EverDrive => Page::EmulatorWarning { emulator, install_emulator: Some(false), emulator_path: emulator_path.clone(), multiworld_path: Some(multiworld_path.clone()) },
                     Emulator::BizHawk | Emulator::Pj64V3 | Emulator::Pj64V4 => Page::LocateEmulator { emulator, install_emulator: false, emulator_path: emulator_path.clone().expect("emulator path must be set for this emulator"), multiworld_path: Some(multiworld_path.clone()) },
                 },
                 Page::InstallMultiworld { emulator, ref emulator_path, ref multiworld_path, .. } | Page::AskLaunch { emulator, ref emulator_path, ref multiworld_path } => match emulator {
-                    Emulator::Dummy | Emulator::EverDrive => unreachable!(),
+                    Emulator::Dummy | Emulator::EverDrive | Emulator::Flashcart => unreachable!(),
                     Emulator::BizHawk | Emulator::Pj64V4 => Page::LocateEmulator { emulator, install_emulator: false, emulator_path: emulator_path.clone().expect("emulator path must be set for BizHawk"), multiworld_path: multiworld_path.clone() },
                     Emulator::Pj64V3 => if let Some(multiworld_path) = multiworld_path.clone() {
                         Page::LocateMultiworld { emulator, emulator_path: emulator_path.clone(), multiworld_path }
@@ -346,7 +347,7 @@ impl State {
                 let current_path = emulator_path.clone();
                 return cmd(async move {
                     Ok(if let Some(emulator_dir) = AsyncFileDialog::new().set_title(match (emulator, install_emulator) {
-                        (Emulator::Dummy | Emulator::EverDrive, _) => unreachable!(),
+                        (Emulator::Dummy | Emulator::EverDrive | Emulator::Flashcart, _) => unreachable!(),
                         (Emulator::BizHawk, false) => "Select BizHawk Folder",
                         (Emulator::BizHawk, true) => "Choose Location for BizHawk Installation",
                         (Emulator::Pj64V3 | Emulator::Pj64V4, false) => "Select Project64 Folder",
@@ -381,6 +382,7 @@ impl State {
                 Page::SelectEmulator { emulator, install_emulator, ref emulator_path, ref multiworld_path } => {
                     let emulator = emulator.expect("emulator must be selected to continue here");
                     match emulator {
+                        Emulator::Flashcart => todo!(),
                         Emulator::EverDrive => {
                             self.page = Page::EmulatorWarning { emulator, install_emulator, emulator_path: emulator_path.clone(), multiworld_path: multiworld_path.clone() };
                             return Task::none()
@@ -406,7 +408,7 @@ impl State {
                     let (install_emulator, emulator_path) = match (install_emulator, emulator_path) {
                         (Some(install_emulator), Some(emulator_path)) => (install_emulator, emulator_path),
                         (_, _) => match emulator {
-                            Emulator::Dummy | Emulator::EverDrive => unreachable!(),
+                            Emulator::Dummy | Emulator::EverDrive | Emulator::Flashcart => unreachable!(),
                             Emulator::BizHawk => if let Some(user_dirs) = UserDirs::new() {
                                 // check for existing BizHawk install in ~/scoop, ~/bin (where this installer places it by default), and the Downloads folder (where the bizhawk-co-op install script places it)
                                 let bizhawk_install_path = user_dirs.home_dir().join("scoop").join("apps").join("bizhawk").join("current");
@@ -470,13 +472,14 @@ impl State {
                 }
                 Page::EmulatorWarning { emulator, install_emulator, ref emulator_path, ref multiworld_path } => match emulator {
                     Emulator::EverDrive => return cmd(future::ok(Message::LocateMultiworld(None))),
+                    Emulator::Flashcart => todo!(),
                     _ => self.page = Page::LocateEmulator { emulator, install_emulator: install_emulator.expect("install_emulator should be evaludated for non-EverDrive"), emulator_path: emulator_path.clone().expect("emulator_path should be evaludated for non-EverDrive"), multiworld_path: multiworld_path.clone() },
                 },
                 Page::LocateEmulator { emulator, install_emulator, ref emulator_path, ref multiworld_path } => if install_emulator {
                     let emulator_path = emulator_path.clone();
                     self.page = Page::InstallEmulator { update: false, emulator, emulator_path: emulator_path.clone(), multiworld_path: multiworld_path.clone() };
                     match emulator {
-                        Emulator::Dummy | Emulator::EverDrive => unreachable!(),
+                        Emulator::Dummy | Emulator::EverDrive | Emulator::Flashcart => unreachable!(),
                         Emulator::BizHawk => {
                             //TODO indicate progress
                             let http_client = self.http_client.clone();
@@ -604,7 +607,7 @@ impl State {
                     }
                 } else {
                     let new_emulator = match emulator {
-                        Emulator::Dummy | Emulator::EverDrive => unreachable!(),
+                        Emulator::Dummy | Emulator::EverDrive | Emulator::Flashcart => unreachable!(),
                         #[cfg(target_os = "windows")] Emulator::BizHawk => {
                             let [major, minor, patch, _] = match winver::get_file_version_info(PathBuf::from(emulator_path).join("EmuHawk.exe")) {
                                 Ok(version) => version,
@@ -698,6 +701,7 @@ impl State {
                     if self.open_emulator {
                         match emulator {
                             Emulator::Dummy => unreachable!(),
+                            Emulator::Flashcart => todo!(),
                             Emulator::EverDrive => {
                                 let multiworld_path = multiworld_path.as_ref().expect("multiworld app path must be set for EverDrive");
                                 if let Err(e) = std::process::Command::new(multiworld_path).spawn() {
@@ -769,6 +773,7 @@ impl State {
                 self.page = Page::InstallMultiworld { emulator, emulator_path: emulator_path.clone(), multiworld_path: multiworld_path.clone(), config_write_failed: false };
                 match emulator {
                     Emulator::Dummy => unreachable!(),
+                    Emulator::Flashcart => todo!(),
                     Emulator::EverDrive => {
                         let create_desktop_shortcut = self.create_multiworld_desktop_shortcut;
                         return cmd(async move {
@@ -889,7 +894,7 @@ impl State {
                 match emulator {
                     Emulator::Dummy => unreachable!(),
                     Emulator::BizHawk | Emulator::Pj64V4 => return cmd(future::ok(Message::InstallMultiworld)),
-                    Emulator::EverDrive | Emulator::Pj64V3 => {
+                    Emulator::EverDrive | Emulator::Flashcart | Emulator::Pj64V3 => {
                         let multiworld_path = if let Some(multiworld_path) = multiworld_path {
                             multiworld_path
                         } else {
@@ -1019,6 +1024,7 @@ impl State {
                         .push("• You will need an EverDrive with a USB port (EverDrive 3.0 or EverDrive X7) and a USB cable that supports data.")
                         .spacing(8)
                         .into(),
+                    Emulator::Flashcart => todo!(),
                     _ => unreachable!(),
                 },
                 true,
@@ -1034,7 +1040,7 @@ impl State {
                             Cow::Owned(format!("{emulator} target folder"))
                         } else {
                             match emulator {
-                                Emulator::Dummy | Emulator::EverDrive => unreachable!(),
+                                Emulator::Dummy | Emulator::EverDrive | Emulator::Flashcart => unreachable!(),
                                 Emulator::BizHawk => {
                                     #[cfg(target_os = "linux")] { Cow::Borrowed("The folder with EmuHawkMono.sh in it") }
                                     #[cfg(target_os = "windows")] { Cow::Borrowed("The folder with EmuHawk.exe in it") }
@@ -1132,6 +1138,7 @@ impl State {
                     col = col.push(Text::new("Multiworld has been installed."));
                     match emulator {
                         Emulator::Dummy => unreachable!(),
+                        Emulator::Flashcart => todo!(),
                         Emulator::EverDrive => {
                             col = col.push(Checkbox::new(self.open_emulator).label("Open Multiworld now").on_toggle(Message::SetOpenEmulator));
                         }

--- a/crate/multiworld-installer/src/main.rs
+++ b/crate/multiworld-installer/src/main.rs
@@ -705,10 +705,9 @@ impl State {
                         match emulator {
                             Emulator::Dummy => unreachable!(),
                             Emulator::Flashcart => {
-                                #[cfg(target_os = "linux")] let multiworld_path = PathBuf::from(multiworld_path.as_ref().expect("multiworld app path must be set for flashcarts")).join("multiworld-gui");
-                                #[cfg(target_os = "windows")] let multiworld_path = PathBuf::from(multiworld_path.as_ref().expect("multiworld app path must be set for flashcarts")).join("multiworld-gui.exe");
-                                if let Err(e) = std::process::Command::new(&multiworld_path).spawn() {
-                                    return cmd(future::ready(Err(e).at(&multiworld_path).map_err(Error::from)))
+                                let multiworld_path = multiworld_path.as_ref().expect("multiworld app path must be set for flashcarts");
+                                if let Err(e) = std::process::Command::new(multiworld_path).spawn() {
+                                    return cmd(future::ready(Err(e).at(multiworld_path).map_err(Error::from)))
                                 }
                             }
                             Emulator::EverDrive => {
@@ -789,12 +788,12 @@ impl State {
                             new_mw_config.default_frontend = Some(Emulator::Flashcart);
                             new_mw_config.save().await?;
                             let multiworld_path = PathBuf::from(multiworld_path.expect("multiworld app path must be set for Flashcart executable"));
-                            fs::create_dir_all(multiworld_path.clone()).await?;
-                            #[cfg(all(target_os = "linux", debug_assertions))] fs::write(&multiworld_path.join("multiworld-gui"), include_bytes!("../../../target/debug/multiworld-gui")).await?;
-                            #[cfg(all(target_os = "linux", not(debug_assertions)))] fs::write(&multiworld_path.join("multiworld-gui"), include_bytes!("../../../target/release/multiworld-gui")).await?;
-                            #[cfg(all(target_os = "linux"))] fs::set_permissions(&multiworld_path.join("multiworld-gui"), std::fs::Permissions::from_mode(0o755)).await?;
-                            #[cfg(all(target_os = "windows", debug_assertions))] fs::write(&multiworld_path.join("multiworld-gui.exe"), include_bytes!("../../../target/debug/multiworld-gui.exe")).await?;
-                            #[cfg(all(target_os = "windows", not(debug_assertions)))] fs::write(&multiworld_path.join("multiworld-gui.exe"), include_bytes!("../../../target/release/multiworld-gui.exe")).await?;
+                            fs::create_dir_all(multiworld_path.parent().ok_or(Error::Root)?).await?;
+                            #[cfg(all(target_os = "linux", debug_assertions))] fs::write(&multiworld_path, include_bytes!("../../../target/debug/multiworld-gui")).await?;
+                            #[cfg(all(target_os = "linux", not(debug_assertions)))] fs::write(&multiworld_path, include_bytes!("../../../target/release/multiworld-gui")).await?;
+                            #[cfg(all(target_os = "linux"))] fs::set_permissions(&multiworld_path, std::fs::Permissions::from_mode(0o755)).await?;
+                            #[cfg(all(target_os = "windows", debug_assertions))] fs::write(&multiworld_path, include_bytes!("../../../target/debug/multiworld-gui.exe")).await?;
+                            #[cfg(all(target_os = "windows", not(debug_assertions)))] fs::write(&multiworld_path, include_bytes!("../../../target/release/multiworld-gui.exe")).await?;
                             #[cfg(target_os = "windows")] {
                                 let base_dirs = BaseDirs::new().ok_or(Error::MissingHomeDir)?;
                                 ShellLink::new(&multiworld_path)?

--- a/crate/multiworld-installer/src/main.rs
+++ b/crate/multiworld-installer/src/main.rs
@@ -705,9 +705,10 @@ impl State {
                         match emulator {
                             Emulator::Dummy => unreachable!(),
                             Emulator::Flashcart => {
-                                let multiworld_path = multiworld_path.as_ref().expect("multiworld app path must be set for flashcarts");
-                                if let Err(e) = std::process::Command::new(multiworld_path).spawn() {
-                                    return cmd(future::ready(Err(e).at(multiworld_path).map_err(Error::from)))
+                                #[cfg(target_os = "linux")] let multiworld_path = PathBuf::from(multiworld_path.as_ref().expect("multiworld app path must be set for flashcarts")).join("multiworld-gui");
+                                #[cfg(target_os = "windows")] let multiworld_path = PathBuf::from(multiworld_path.as_ref().expect("multiworld app path must be set for flashcarts")).join("multiworld-gui.exe");
+                                if let Err(e) = std::process::Command::new(&multiworld_path).spawn() {
+                                    return cmd(future::ready(Err(e).at(&multiworld_path).map_err(Error::from)))
                                 }
                             }
                             Emulator::EverDrive => {
@@ -785,18 +786,15 @@ impl State {
                         let create_desktop_shortcut = self.create_multiworld_desktop_shortcut;
                         return cmd(async move {
                             let mut new_mw_config = Config::load().await?;
-                            new_mw_config.default_frontend = Some(Emulator::EverDrive);
+                            new_mw_config.default_frontend = Some(Emulator::Flashcart);
                             new_mw_config.save().await?;
-                            let multiworld_path = PathBuf::from(multiworld_path.expect("multiworld app path must be set for Project64"));
-                            fs::create_dir_all(multiworld_path.parent().ok_or(Error::Root)?).await?;
+                            let multiworld_path = PathBuf::from(multiworld_path.expect("multiworld app path must be set for Flashcart executable"));
+                            fs::create_dir_all(multiworld_path.clone()).await?;
                             #[cfg(all(target_os = "linux", debug_assertions))] fs::write(&multiworld_path.join("multiworld-gui"), include_bytes!("../../../target/debug/multiworld-gui")).await?;
-                            #[cfg(all(target_os = "linux", debug_assertions))] fs::write(&multiworld_path.join("libflashcart.so"), include_bytes!("../../../target/debug/libflashcart.so")).await?;
                             #[cfg(all(target_os = "linux", not(debug_assertions)))] fs::write(&multiworld_path.join("multiworld-gui"), include_bytes!("../../../target/release/multiworld-gui")).await?;
-                            #[cfg(all(target_os = "linux", not(debug_assertions)))] fs::write(&multiworld_path.join("libflashcart.so"), include_bytes!("../../../target/release/libflashcart.so")).await?;
+                            #[cfg(all(target_os = "linux"))] fs::set_permissions(&multiworld_path.join("multiworld-gui"), std::fs::Permissions::from_mode(0o755)).await?;
                             #[cfg(all(target_os = "windows", debug_assertions))] fs::write(&multiworld_path.join("multiworld-gui.exe"), include_bytes!("../../../target/debug/multiworld-gui.exe")).await?;
-                            #[cfg(all(target_os = "windows", debug_assertions))] fs::write(&multiworld_path.join("Flashcart_x64.dll"), include_bytes!("../../../target/debug/Flashcart_x64.dll")).await?;
                             #[cfg(all(target_os = "windows", not(debug_assertions)))] fs::write(&multiworld_path.join("multiworld-gui.exe"), include_bytes!("../../../target/release/multiworld-gui.exe")).await?;
-                            #[cfg(all(target_os = "windows", not(debug_assertions)))] fs::write(&multiworld_path.join("Flashcart_x64.dll"), include_bytes!("../../../target/release/Flashcart_x64.dll")).await?;
                             #[cfg(target_os = "windows")] {
                                 let base_dirs = BaseDirs::new().ok_or(Error::MissingHomeDir)?;
                                 ShellLink::new(&multiworld_path)?

--- a/crate/multiworld-installer/src/main.rs
+++ b/crate/multiworld-installer/src/main.rs
@@ -329,7 +329,7 @@ impl State {
                 Page::InstallEmulator { .. } => unreachable!(),
                 Page::LocateMultiworld { emulator, ref emulator_path, ref multiworld_path } => match emulator {
                     Emulator::Dummy => unreachable!(),
-                    Emulator::Flashcart => todo!(),
+                    Emulator::Flashcart => Page::EmulatorWarning { emulator, install_emulator: Some(false), emulator_path: emulator_path.clone(), multiworld_path: Some(multiworld_path.clone()) },
                     Emulator::EverDrive => Page::EmulatorWarning { emulator, install_emulator: Some(false), emulator_path: emulator_path.clone(), multiworld_path: Some(multiworld_path.clone()) },
                     Emulator::BizHawk | Emulator::Pj64V3 | Emulator::Pj64V4 => Page::LocateEmulator { emulator, install_emulator: false, emulator_path: emulator_path.clone().expect("emulator path must be set for this emulator"), multiworld_path: Some(multiworld_path.clone()) },
                 },
@@ -382,7 +382,10 @@ impl State {
                 Page::SelectEmulator { emulator, install_emulator, ref emulator_path, ref multiworld_path } => {
                     let emulator = emulator.expect("emulator must be selected to continue here");
                     match emulator {
-                        Emulator::Flashcart => todo!(),
+                        Emulator::Flashcart => {
+                            self.page = Page::EmulatorWarning { emulator, install_emulator, emulator_path: emulator_path.clone(), multiworld_path: multiworld_path.clone() };
+                            return Task::none()
+                        }
                         Emulator::EverDrive => {
                             self.page = Page::EmulatorWarning { emulator, install_emulator, emulator_path: emulator_path.clone(), multiworld_path: multiworld_path.clone() };
                             return Task::none()
@@ -472,7 +475,7 @@ impl State {
                 }
                 Page::EmulatorWarning { emulator, install_emulator, ref emulator_path, ref multiworld_path } => match emulator {
                     Emulator::EverDrive => return cmd(future::ok(Message::LocateMultiworld(None))),
-                    Emulator::Flashcart => todo!(),
+                    Emulator::Flashcart => return cmd(future::ok(Message::LocateMultiworld(None))),
                     _ => self.page = Page::LocateEmulator { emulator, install_emulator: install_emulator.expect("install_emulator should be evaludated for non-EverDrive"), emulator_path: emulator_path.clone().expect("emulator_path should be evaludated for non-EverDrive"), multiworld_path: multiworld_path.clone() },
                 },
                 Page::LocateEmulator { emulator, install_emulator, ref emulator_path, ref multiworld_path } => if install_emulator {
@@ -701,7 +704,12 @@ impl State {
                     if self.open_emulator {
                         match emulator {
                             Emulator::Dummy => unreachable!(),
-                            Emulator::Flashcart => todo!(),
+                            Emulator::Flashcart => {
+                                let multiworld_path = multiworld_path.as_ref().expect("multiworld app path must be set for flashcarts");
+                                if let Err(e) = std::process::Command::new(multiworld_path).spawn() {
+                                    return cmd(future::ready(Err(e).at(multiworld_path).map_err(Error::from)))
+                                }
+                            }
                             Emulator::EverDrive => {
                                 let multiworld_path = multiworld_path.as_ref().expect("multiworld app path must be set for EverDrive");
                                 if let Err(e) = std::process::Command::new(multiworld_path).spawn() {
@@ -773,7 +781,35 @@ impl State {
                 self.page = Page::InstallMultiworld { emulator, emulator_path: emulator_path.clone(), multiworld_path: multiworld_path.clone(), config_write_failed: false };
                 match emulator {
                     Emulator::Dummy => unreachable!(),
-                    Emulator::Flashcart => todo!(),
+                    Emulator::Flashcart => {
+                        let create_desktop_shortcut = self.create_multiworld_desktop_shortcut;
+                        return cmd(async move {
+                            let mut new_mw_config = Config::load().await?;
+                            new_mw_config.default_frontend = Some(Emulator::EverDrive);
+                            new_mw_config.save().await?;
+                            let multiworld_path = PathBuf::from(multiworld_path.expect("multiworld app path must be set for Project64"));
+                            fs::create_dir_all(multiworld_path.parent().ok_or(Error::Root)?).await?;
+                            #[cfg(all(target_os = "linux", debug_assertions))] fs::write(&multiworld_path.join("multiworld-gui"), include_bytes!("../../../target/debug/multiworld-gui")).await?;
+                            #[cfg(all(target_os = "linux", debug_assertions))] fs::write(&multiworld_path.join("libflashcart.so"), include_bytes!("../../../target/debug/libflashcart.so")).await?;
+                            #[cfg(all(target_os = "linux", not(debug_assertions)))] fs::write(&multiworld_path.join("multiworld-gui"), include_bytes!("../../../target/release/multiworld-gui")).await?;
+                            #[cfg(all(target_os = "linux", not(debug_assertions)))] fs::write(&multiworld_path.join("libflashcart.so"), include_bytes!("../../../target/release/libflashcart.so")).await?;
+                            #[cfg(all(target_os = "windows", debug_assertions))] fs::write(&multiworld_path.join("multiworld-gui.exe"), include_bytes!("../../../target/debug/multiworld-gui.exe")).await?;
+                            #[cfg(all(target_os = "windows", debug_assertions))] fs::write(&multiworld_path.join("Flashcart_x64.dll"), include_bytes!("../../../target/debug/Flashcart_x64.dll")).await?;
+                            #[cfg(all(target_os = "windows", not(debug_assertions)))] fs::write(&multiworld_path.join("multiworld-gui.exe"), include_bytes!("../../../target/release/multiworld-gui.exe")).await?;
+                            #[cfg(all(target_os = "windows", not(debug_assertions)))] fs::write(&multiworld_path.join("Flashcart_x64.dll"), include_bytes!("../../../target/release/Flashcart_x64.dll")).await?;
+                            #[cfg(target_os = "windows")] {
+                                let base_dirs = BaseDirs::new().ok_or(Error::MissingHomeDir)?;
+                                ShellLink::new(&multiworld_path)?
+                                    .create_lnk(base_dirs.data_dir().join("Microsoft").join("Windows").join("Start Menu").join("Programs").join("Mido's House Multiworld.lnk"))?;
+                                if create_desktop_shortcut {
+                                    let user_dirs = UserDirs::new().ok_or(Error::MissingHomeDir)?;
+                                    ShellLink::new(multiworld_path)?
+                                        .create_lnk(user_dirs.desktop_dir().ok_or(Error::MissingDesktopDir)?.join("Mido's House Multiworld.lnk"))?;
+                                }
+                            }
+                            Ok(Message::MultiworldInstalled)
+                        })
+                    },
                     Emulator::EverDrive => {
                         let create_desktop_shortcut = self.create_multiworld_desktop_shortcut;
                         return cmd(async move {
@@ -1024,7 +1060,18 @@ impl State {
                         .push("• You will need an EverDrive with a USB port (EverDrive 3.0 or EverDrive X7) and a USB cable that supports data.")
                         .spacing(8)
                         .into(),
-                    Emulator::Flashcart => todo!(),
+                    Emulator::Flashcart => Column::new()
+                        .push(Text::new("Warnings").size(24))
+                        .push("• Console support is currently experimental and requires Fenhl's branch of the randomizer.")
+                        .push(Row::new()
+                            .push(Button::new("Generate Seed").on_press(Message::DevFenhlWeb))
+                            .push(Button::new("GitHub Source").on_press(Message::DevFenhlGitHub))
+                            .spacing(8)
+                        )
+                        .push("• For N64, you will need a Summercart64, 64Drive, or an EverDrive with a USB port (EverDrive 3.0 or EverDrive X7), as well as a USB cable that supports data.")
+                        .push("• For Wii, you will need two FTDI chipset USB-to-serial adapters (FT232R, FT232H, or FT230X) connected via a null modem adapter.")
+                        .spacing(8)
+                        .into(),
                     _ => unreachable!(),
                 },
                 true,
@@ -1138,7 +1185,9 @@ impl State {
                     col = col.push(Text::new("Multiworld has been installed."));
                     match emulator {
                         Emulator::Dummy => unreachable!(),
-                        Emulator::Flashcart => todo!(),
+                        Emulator::Flashcart => {
+                            col = col.push(Checkbox::new(self.open_emulator).label("Open Multiworld now").on_toggle(Message::SetOpenEmulator));
+                        }
                         Emulator::EverDrive => {
                             col = col.push(Checkbox::new(self.open_emulator).label("Open Multiworld now").on_toggle(Message::SetOpenEmulator));
                         }

--- a/crate/multiworld-updater/src/main.rs
+++ b/crate/multiworld-updater/src/main.rs
@@ -239,7 +239,7 @@ impl App {
             Message::Exited => {
                 self.state = State::GetMultiworldRelease;
                 let (asset_name, script_name) = match self.args {
-                    EmuArgs::EverDrive { .. } => {
+                    EmuArgs::Flashcart { .. } | EmuArgs::EverDrive { .. } => {
                         #[cfg(target_os = "linux")] { ("multiworld-gui-linux", None) }
                         #[cfg(target_os = "windows")] { ("multiworld-pj64.exe", None) }
                     }
@@ -358,7 +358,7 @@ impl App {
                         }
                     })
                 }
-                EmuArgs::EverDrive { ref path, .. } | EmuArgs::Pj64 { ref path, .. } => {
+                EmuArgs::Flashcart { ref path, .. } | EmuArgs::EverDrive { ref path, .. } | EmuArgs::Pj64 { ref path, .. } => {
                     self.state = State::Replace;
                     let path = path.clone();
                     return cmd(async move {
@@ -444,7 +444,7 @@ impl App {
                         Ok(Message::Done)
                     })
                 }
-                EmuArgs::EverDrive { ref path, .. } | EmuArgs::Pj64 { ref path, .. } => {
+                EmuArgs::Flashcart { ref path, .. } | EmuArgs::EverDrive { ref path, .. } | EmuArgs::Pj64 { ref path, .. } => {
                     self.state = State::Launch;
                     let path = path.clone();
                     return cmd(async move {
@@ -494,7 +494,7 @@ impl App {
                     .spacing(8)
                     .padding(8)
                     .into(),
-                EmuArgs::EverDrive { .. } | EmuArgs::Pj64 { .. } => Column::new()
+                EmuArgs::Flashcart { .. } | EmuArgs::EverDrive { .. } | EmuArgs::Pj64 { .. } => Column::new()
                     .push("An update for Mido's House Multiworld is available.")
                     .push("Waiting to make sure the old version has exited…")
                     .push(Space::default().height(Length::Fill))
@@ -580,6 +580,10 @@ fn pj64script(src: &Path, dst: &Path) -> wheel::Result {
 #[derive(Clone, clap::Subcommand)]
 #[clap(rename_all = "lower")]
 enum EmuArgs {
+    Flashcart {
+        path: PathBuf,
+        pid: Pid,
+    },
     EverDrive {
         path: PathBuf,
         pid: Pid,
@@ -641,7 +645,7 @@ fn main(args: Args) -> Result<(), MainError> {
                                     sleep(Duration::from_secs(1)).await;
                                 }
                             }
-                            EmuArgs::EverDrive { pid, .. } | EmuArgs::Pj64 { pid, .. } => {
+                            EmuArgs::Flashcart { pid, .. } | EmuArgs::EverDrive { pid, .. } | EmuArgs::Pj64 { pid, .. } => {
                                 while system.refresh_processes_specifics(ProcessesToUpdate::Some(&[pid]), true, ProcessRefreshKind::default()) > 0 {
                                     sleep(Duration::from_secs(1)).await;
                                 }

--- a/crate/multiworld/src/frontend.rs
+++ b/crate/multiworld/src/frontend.rs
@@ -27,6 +27,7 @@ pub const PROTOCOL_VERSION: u8 = 8;
 pub enum Kind {
     Dummy,
     EverDrive,
+    Flashcart,
     BizHawk,
     Pj64V3,
     Pj64V4,
@@ -37,6 +38,7 @@ impl Kind {
         match self {
             Self::Dummy => false,
             Self::EverDrive => true,
+            Self::Flashcart => true,
             Self::BizHawk => cfg!(any(target_os = "linux", target_os = "windows")),
             Self::Pj64V3 => cfg!(target_os = "windows"),
             Self::Pj64V4 => false, // hide until Project64 version 4 is released
@@ -49,6 +51,7 @@ impl fmt::Display for Kind {
         match self {
             Self::Dummy => write!(f, "(no frontend)"),
             Self::EverDrive => write!(f, "EverDrive"),
+            Self::Flashcart => write!(f, "Flashcart"),
             Self::BizHawk => write!(f, "BizHawk"),
             Self::Pj64V3 | Self::Pj64V4 => write!(f, "Project64"),
         }

--- a/crate/multiworld/src/frontend.rs
+++ b/crate/multiworld/src/frontend.rs
@@ -37,7 +37,7 @@ impl Kind {
     pub fn is_supported(&self) -> bool {
         match self {
             Self::Dummy => false,
-            Self::EverDrive => true,
+            Self::EverDrive => false,
             Self::Flashcart => true,
             Self::BizHawk => cfg!(any(target_os = "linux", target_os = "windows")),
             Self::Pj64V3 => cfg!(target_os = "windows"),
@@ -50,8 +50,8 @@ impl fmt::Display for Kind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Dummy => write!(f, "(no frontend)"),
-            Self::EverDrive => write!(f, "EverDrive"),
-            Self::Flashcart => write!(f, "Flashcart"),
+            Self::EverDrive => write!(f, "EverDrive (legacy)"),
+            Self::Flashcart => write!(f, "Console (Wii or N64)"),
             Self::BizHawk => write!(f, "BizHawk"),
             Self::Pj64V3 | Self::Pj64V4 => write!(f, "Project64"),
         }


### PR DESCRIPTION
Closes #53. Partially implements #60 as a side effect of Wii VC support, but requires additional hardware.

Companion PR to the ROM-side changes in fenhl/OoT-Randomizer#34

This replaces the previous Everdrive-specific implementation with [UNFLoader](https://github.com/buu342/N64-UNFLoader/)'s example generic [USB library](https://github.com/buu342/N64-UNFLoader/tree/master/USB%2BDebug%20Library) for serial communication. The UNFLoader protocol is extended to include OOTR-specific message types, more reliable timeout on read failures, some memory leak fixes for the Everdrive functions, and Wii VC support. Ideally, this protocol can be further extended for PC emulators with a system similar to the Wii to enable standardized auto-tracking on top of the multiworld functionality.

The Everdrive-specific code is retained, but the option is removed from the GUI in favor of the new `Console (Wii or N64)` frontend.

Logging USB messages to file is turned on in this PR, but can easily be turned off by setting `DEBUG_LOGGING` in `flashcart.rs` to false. I've found it useful for diagnosing comms failures from others and recommend keeping it on. The same log messages are also printed to console on macOS and Linux.

UNFLoader's C++ code is referenced via the Rust wrapper crate [n64flashcart](https://github.com/mracsys/n64usb/tree/main/crate/n64flashcart), which builds UNFLoader's flashcart library via bindgen. Building the multiworld GUI on Linux and macOS now requires LLVM as well as static libraries for `libftdi` and `libusb`. Not all Linux distributions include static versions of the libraries (notably Fedora, but not Debian). I've only tested building on macOS with dependencies installed via Homebrew. Windows is more straightforward with all dependencies bundled in the crate other than LLVM. Build instructions are included for the library and example app at the root of the repository. The wrapper and UNFLoader itself use compatible licenses if it's desired to move the crate under the ootr-multiworld repo instead.

Reference the ROM PR for specifics on the protocol changes.